### PR TITLE
Update actions permissions

### DIFF
--- a/.github/workflows/gh-aw-pr-review.lock.yml
+++ b/.github/workflows/gh-aw-pr-review.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"c17b1a22d7ca619905687dacf20db14acebff5a78780b10320144b818afa3110"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"ba77c0c2415f5a139894efaad7603b9bfc4f39d3143c59d3ce073bb0954f31ea"}
 
 name: "PR Review"
 "on":
@@ -613,7 +613,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      copilot-requests: write
       issues: read
       pull-requests: read
     concurrency:
@@ -636,6 +635,7 @@ jobs:
       model: ${{ steps.generate_aw_info.outputs.model }}
       output: ${{ steps.collect_output.outputs.output }}
       output_types: ${{ steps.collect_output.outputs.output_types }}
+      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
         uses: github/gh-aw/actions/setup@fad43e3c91a4e1d43e458f68e96574127934e7d1 # v0.50.1
@@ -766,6 +766,11 @@ jobs:
             
             // Set model as output for reuse in other steps/jobs
             core.setOutput('model', awInfo.model);
+      - name: Validate COPILOT_GITHUB_TOKEN secret
+        id: validate-secret
+        run: /opt/gh-aw/actions/validate_multi_secret.sh COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       - name: Install GitHub Copilot CLI
         run: /opt/gh-aw/actions/install_copilot_cli.sh 0.0.415
       - name: Install awf binary
@@ -1174,7 +1179,7 @@ jobs:
             -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --allow-all-tools --allow-all-paths --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           COPILOT_MODEL: ${{ inputs.model }}
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1184,7 +1189,6 @@ jobs:
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
           GITHUB_WORKSPACE: ${{ github.workspace }}
-          S2STOKENS: true
           XDG_CONFIG_HOME: /home/runner
       - name: Configure Git credentials
         env:
@@ -1234,7 +1238,8 @@ jobs:
             const { main } = require('/opt/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1392,14 +1397,13 @@ jobs:
             -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(jq)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(wc)'\'' --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/threat-detection/detection.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           COPILOT_MODEL: ${{ inputs.model }}
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
           GITHUB_WORKSPACE: ${{ github.workspace }}
-          S2STOKENS: true
           XDG_CONFIG_HOME: /home/runner
       - name: Parse threat detection results
         id: parse_detection_results
@@ -1505,6 +1509,7 @@ jobs:
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_WORKFLOW_ID: "gh-aw-pr-review"
+          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.agent.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"${{ inputs.messages-footer || '---\\n[What is this?](https://ela.st/github-ai-tools) | [From workflow: {workflow_name}]({run_url})\\n\\nGive us feedback! React with 🚀 if perfect, 👍 if helpful, 👎 if not.' }}\",\"activationComments\":\"false\"}"
           GH_AW_GROUP_REPORTS: "false"

--- a/.github/workflows/gh-aw-pr-review.md
+++ b/.github/workflows/gh-aw-pr-review.md
@@ -14,8 +14,6 @@ imports:
   - gh-aw-fragments/safe-output-review-comment.md
   - gh-aw-fragments/safe-output-submit-review.md
   - gh-aw-fragments/network-ecosystems.md
-features:
-  copilot-requests: true
 engine:
   id: copilot
   model: ${{ inputs.model }}

--- a/.github/workflows/trigger-bug-exterminator.yml
+++ b/.github/workflows/trigger-bug-exterminator.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-bug-hunter.yml
+++ b/.github/workflows/trigger-bug-hunter.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/trigger-code-duplication-fixer.yml
+++ b/.github/workflows/trigger-code-duplication-fixer.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: read
   pull-requests: write

--- a/.github/workflows/trigger-code-simplifier.yml
+++ b/.github/workflows/trigger-code-simplifier.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-downstream-health.yml
+++ b/.github/workflows/trigger-downstream-health.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/trigger-newbie-contributor-fixer.yml
+++ b/.github/workflows/trigger-newbie-contributor-fixer.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-pr-review.yml
+++ b/.github/workflows/trigger-pr-review.yml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
+  actions: read
   contents: read
   issues: write  # needed for no-op run tracking issue
   pull-requests: write

--- a/.github/workflows/trigger-refactor-opportunist.yml
+++ b/.github/workflows/trigger-refactor-opportunist.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/trigger-small-problem-fixer.yml
+++ b/.github/workflows/trigger-small-problem-fixer.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-test-improver.yml
+++ b/.github/workflows/trigger-test-improver.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-text-beautifier.yml
+++ b/.github/workflows/trigger-text-beautifier.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: read
   pull-requests: write

--- a/gh-agent-workflows/bug-exterminator/example.yml
+++ b/gh-agent-workflows/bug-exterminator/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/bug-hunter/example.yml
+++ b/gh-agent-workflows/bug-hunter/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/gh-agent-workflows/code-duplication-fixer/example.yml
+++ b/gh-agent-workflows/code-duplication-fixer/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: read
   pull-requests: write

--- a/gh-agent-workflows/code-simplifier/example.yml
+++ b/gh-agent-workflows/code-simplifier/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/downstream-health/example.yml
+++ b/gh-agent-workflows/downstream-health/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/gh-agent-workflows/issue-fixer/example.yml
+++ b/gh-agent-workflows/issue-fixer/example.yml
@@ -4,6 +4,7 @@ on:
     types: [opened]
 
 permissions:
+  actions: read
   contents: read
   discussions: write
   issues: write

--- a/gh-agent-workflows/newbie-contributor-fixer/example.yml
+++ b/gh-agent-workflows/newbie-contributor-fixer/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/pr-review/example.yml
+++ b/gh-agent-workflows/pr-review/example.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
+  actions: read
   contents: read
   issues: write  # needed for no-op run tracking issue
   pull-requests: write

--- a/gh-agent-workflows/refactor-opportunist/example.yml
+++ b/gh-agent-workflows/refactor-opportunist/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/gh-agent-workflows/release-update/example.yml
+++ b/gh-agent-workflows/release-update/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/scheduled-audit/example.yml
+++ b/gh-agent-workflows/scheduled-audit/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/gh-agent-workflows/scheduled-fix/example.yml
+++ b/gh-agent-workflows/scheduled-fix/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: read
   pull-requests: write

--- a/gh-agent-workflows/small-problem-fixer/example.yml
+++ b/gh-agent-workflows/small-problem-fixer/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/test-improver/example.yml
+++ b/gh-agent-workflows/test-improver/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/text-beautifier/example.yml
+++ b/gh-agent-workflows/text-beautifier/example.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: read
   pull-requests: write


### PR DESCRIPTION
## Summary

- Adds explicit `actions: read` permissions to trigger workflows and `gh-agent-workflows/*/example.yml` templates.
- Tightens `PR Review` workflow auth by validating `COPILOT_GITHUB_TOKEN` and using that secret for Copilot runs.
- Removes `copilot-requests` feature usage and drops redundant `S2STOKENS` environment variables.
- Extends secret redaction and run metadata to include `COPILOT_GITHUB_TOKEN` verification results.

## Why this change

These updates make workflow permissions and authentication paths explicit and consistent, reducing implicit token behavior and improving security posture for automation runs.

## Scope notes

- The `.github/workflows/gh-aw-pr-review.lock.yml` updates are generated lockfile changes that reflect the source updates in `.github/workflows/gh-aw-pr-review.md` and related workflow config.

> Generated by [Update PR Body](https://github.com/elastic/ai-github-actions/actions/runs/22374856140) for issue #400

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22374856140, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions/actions/runs/22374856140 -->