### PR TITLE
Fix deep-research trigger: grant pull-requests: write

### DIFF
--- a/.github/workflows/trigger-deep-research.yml
+++ b/.github/workflows/trigger-deep-research.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
   discussions: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:

--- a/gh-agent-workflows/deep-research/example.yml
+++ b/gh-agent-workflows/deep-research/example.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
   discussions: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:


### PR DESCRIPTION
## Summary
- The reusable workflow `gh-aw-deep-research.lock.yml` has `activation` and `pre_activation` jobs that request `pull-requests: write`
- The trigger workflow only granted `pull-requests: read`, causing the workflow validation error:
  > The nested job 'activation' is requesting 'pull-requests: write', but is only allowed 'pull-requests: read'
- Updated both the example and dogfood trigger to grant `pull-requests: write`

## Test plan
- [ ] Verify the trigger-deep-research workflow passes GitHub Actions validation
- [ ] Test `/research` command on an issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)