### PR TITLE
Update trigger-ci-workflows.sh to match current workflows

### DIFF
--- a/scripts/trigger-ci-workflows.sh
+++ b/scripts/trigger-ci-workflows.sh
@@ -2,11 +2,11 @@
 # Trigger continuous-improvement workflows via workflow_dispatch.
 #
 # Usage:
-#   ./scripts/trigger-ci-workflows.sh                # trigger all categories
-#   ./scripts/trigger-ci-workflows.sh detectors       # trigger one category
-#   ./scripts/trigger-ci-workflows.sh improvers monitors  # trigger multiple categories
-#   ./scripts/trigger-ci-workflows.sh --dry-run       # show what would be triggered
-#   ./scripts/trigger-ci-workflows.sh --list          # list workflows by category
+#   ./scripts/trigger-ci-workflows.sh                    # trigger all categories
+#   ./scripts/trigger-ci-workflows.sh detectors           # trigger one category
+#   ./scripts/trigger-ci-workflows.sh fixers monitors     # trigger multiple categories
+#   ./scripts/trigger-ci-workflows.sh --dry-run           # show what would be triggered
+#   ./scripts/trigger-ci-workflows.sh --list              # list workflows by category
 
 set -euo pipefail
 
@@ -16,36 +16,34 @@ REF="main"
 # --- Categories ---
 
 DETECTORS=(
+  "Trigger Autonomy Atomicity Analyzer"
   "Trigger Breaking Change Detector"
   "Trigger Bug Hunter"
-  "Trigger Docs Patrol"
-  "Trigger Newbie Contributor Patrol"
   "Trigger Code Duplication Detector"
-  "Trigger Stale Issues"
+  "Trigger Docs Patrol"
+  "Trigger Framework Best Practices"
+  "Trigger Information Architecture"
+  "Trigger Newbie Contributor Patrol"
+  "Trigger Prompt Audit"
+  "Trigger Stale Issues Investigator"
   "Trigger Test Coverage Detector"
   "Trigger Text Auditor"
+  "Trigger UX Design Patrol"
 )
 
-IMPROVERS=(
-  "Trigger Bug Exterminator"
-  "Trigger Code Duplication Fixer"
-  "Trigger Code Simplifier"
-  "Trigger Newbie Contributor Fixer"
-  "Trigger Small Problem Fixer"
-  "Trigger Test Improver"
-  "Trigger Text Beautifier"
+FIXERS=(
+  "Trigger Refactor Opportunist"
+  "Trigger Stale Issues Remediator"
 )
 
 MONITORS=(
-  "Agent Deep Dive"
-  "Agent Efficiency"
   "Trigger Agent Suggestions"
-  "Trigger Downstream Health"
+  "Trigger Estc Downstream Health"
+  "Trigger Product Manager Impersonator"
   "Trigger Project Summary"
-  "Trigger Release Update Check"
 )
 
-ALL_CATEGORIES=(detectors improvers monitors)
+ALL_CATEGORIES=(detectors fixers monitors)
 
 # --- Argument parsing ---
 
@@ -60,10 +58,10 @@ for arg in "$@"; do
     --help|-h)
       echo "Usage: $0 [--dry-run] [--list] [category ...]"
       echo ""
-      echo "Categories: detectors, improvers, monitors"
+      echo "Categories: detectors, fixers, monitors"
       echo "  detectors  — find issues, drift, stale items, breaking changes"
-      echo "  improvers  — fix bugs, simplify code, improve tests/text/perf"
-      echo "  monitors   — efficiency reports, downstream health, project summaries"
+      echo "  fixers     — refactor code, remediate stale issues"
+      echo "  monitors   — downstream health, project summaries, suggestions"
       echo ""
       echo "  --dry-run  Show what would be triggered without dispatching"
       echo "  --list     List workflows by category"
@@ -71,11 +69,11 @@ for arg in "$@"; do
       echo "If no categories are specified, all are triggered."
       exit 0
       ;;
-    detectors|improvers|monitors)
+    detectors|fixers|monitors)
       CATEGORIES+=("$arg")
       ;;
     *)
-      echo "Unknown argument: $arg (expected: detectors, improvers, monitors, --dry-run, --list)" >&2
+      echo "Unknown argument: $arg (expected: detectors, fixers, monitors, --dry-run, --list)" >&2
       exit 1
       ;;
   esac
@@ -91,7 +89,7 @@ get_workflows() {
   local category="$1"
   case "$category" in
     detectors) printf '%s\n' "${DETECTORS[@]}" ;;
-    improvers) printf '%s\n' "${IMPROVERS[@]}" ;;
+    fixers)    printf '%s\n' "${FIXERS[@]}" ;;
     monitors)  printf '%s\n' "${MONITORS[@]}" ;;
   esac
 }
@@ -139,7 +137,7 @@ if [[ "$DRY_RUN" == "false" ]]; then
   for category in "${CATEGORIES[@]}"; do
     case "$category" in
       detectors) total=$((total + ${#DETECTORS[@]})) ;;
-      improvers) total=$((total + ${#IMPROVERS[@]})) ;;
+      fixers)    total=$((total + ${#FIXERS[@]})) ;;
       monitors)  total=$((total + ${#MONITORS[@]})) ;;
     esac
   done


### PR DESCRIPTION
## Summary
- Remove the **IMPROVERS** category — all 7 workflows (Bug Exterminator, Code Duplication Fixer, Code Simplifier, Newbie Contributor Fixer, Small Problem Fixer, Test Improver, Text Beautifier) have been phased out and their trigger files deleted
- Replace with **FIXERS** category containing the 2 remaining scheduled fixer workflows: Refactor Opportunist and Stale Issues Remediator
- Add 6 missing detectors to **DETECTORS**: Autonomy Atomicity Analyzer, Framework Best Practices, Information Architecture, Prompt Audit, UX Design Patrol, and rename `Stale Issues` → `Stale Issues Investigator`
- Fix **MONITORS**: remove 3 dead entries (Agent Deep Dive, Agent Efficiency, Release Update Check), correct `Downstream Health` → `Estc Downstream Health`, add Product Manager Impersonator

## Test plan
- [ ] `./scripts/trigger-ci-workflows.sh --list` shows all 19 scheduled workflows across 3 categories
- [ ] `./scripts/trigger-ci-workflows.sh --dry-run` completes without errors
- [ ] Category names match actual workflow names in `.github/workflows/trigger-*.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)