### PR TITLE
Add structured context passing for self-review sub-agents

### DIFF
--- a/.github/workflows/downstream-users.lock.yml
+++ b/.github/workflows/downstream-users.lock.yml
@@ -36,7 +36,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"86282249cfd2692685a4ce3027d1ee48cfa60c2cd21dcfcb9176fc087e31e71a"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"ee75a9344e26e7442384ab60e7fb442a6fd9c16970e0f3c871392bcc413eec8b"}
 
 name: "Internal: Downstream Users"
 "on":
@@ -888,6 +888,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -911,18 +912,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-bug-exterminator.lock.yml
+++ b/.github/workflows/gh-aw-bug-exterminator.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"0a3772d00132d2172eee1149c9b498c772fc922167fe52813341d1a17412f7b2"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"dc50f9e7bea5d0b9f01420b5a891599052e4bc1c16a5eb1cff61b0a186aa64f8"}
 
 name: "Gh Aw Bug Exterminator"
 "on":
@@ -938,6 +938,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -961,18 +962,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-code-duplication-fixer.lock.yml
+++ b/.github/workflows/gh-aw-code-duplication-fixer.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"a718d1ac10df16ff061df25c796930eda69eb2aed015ba0d53919e94b258475c"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"cb102672858f29b7a9b0ade7b42d095aa6fd7d8e79c66f2e0a763334831b1280"}
 
 name: "Code Duplication Fixer"
 "on":
@@ -940,6 +940,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -963,18 +964,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-code-simplifier.lock.yml
+++ b/.github/workflows/gh-aw-code-simplifier.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"629a36e1205ac0846a504ca442ffd0d052a7e10da309f8cf486578817559b8e1"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"e27c7544fe4d4cf523966cbd290d1b205fb7d7654a37d2f43f05e6bfcd1d6e80"}
 
 name: "Code Simplifier"
 "on":
@@ -955,6 +955,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -978,18 +979,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-fragments/safe-output-create-pr.md
+++ b/.github/workflows/gh-aw-fragments/safe-output-create-pr.md
@@ -34,6 +34,7 @@ safe-inputs:
 
       contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
       pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+      agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
       # Generate diff of all local changes vs upstream for self-review
       # Try --merge-base (vs common ancestor), fall back to
       # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -57,18 +58,71 @@ safe-inputs:
           if result.stdout.strip():
               stat_text = result.stdout.strip()
               break
+      # Capture commit messages so the sub-agent knows what changed and why
+      commits_text = ''
+      for log_cmd in [
+          ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+          ['git', 'log', '--format=### %s%n%n%b', '-10'],
+      ]:
+          result = run(log_cmd)
+          if result.stdout.strip():
+              commits_text = result.stdout.strip()
+              break
       os.makedirs('/tmp/self-review', exist_ok=True)
       with open('/tmp/self-review/diff.patch', 'w') as f:
           f.write(diff_text)
       with open('/tmp/self-review/stat.txt', 'w') as f:
           f.write(stat_text)
+      with open('/tmp/self-review/commits.txt', 'w') as f:
+          f.write(commits_text)
+      # Write manifest so the sub-agent has structured context without
+      # relying on the main agent to manually pass it in the prompt
       diff_line_count = len(diff_text.splitlines())
+      manifest_lines = [
+          '# Self-Review Context',
+          '',
+          'You are reviewing unpushed changes before they are submitted as a new PR.',
+          '',
+          '## Available files',
+          '',
+          'All files are in `/tmp/self-review/`:',
+          '',
+          f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+          '- `stat.txt` : File-level change summary',
+          '- `commits.txt` : Commit messages describing what was changed and why',
+          '- `notes.md` : Author notes on what was done, why, and key decisions made',
+          '',
+          '## How to review',
+          '',
+          '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+          '2. Read `commits.txt` for the commit-level view of what changed.',
+          '3. Read `stat.txt` for a high-level view of which files changed.',
+          '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+      ]
+      step = 5
+      if agents_md:
+          manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+      manifest_lines += [
+          '',
+          '## Focus areas',
+          '',
+          'Look for bugs, logic errors, missed edge cases, and style issues.',
+          'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+          '',
+          '## What NOT to flag',
+          '',
+          '- Pre-existing issues not introduced by these changes',
+          '- Style preferences handled by linters or formatters',
+          '- Theoretical performance concerns without evidence of real-world impact',
+      ]
+      with open('/tmp/self-review/README.md', 'w') as f:
+          f.write('\n'.join(manifest_lines) + '\n')
       checklist = []
       if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
       if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
       checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
       if diff_line_count > 0:
-          checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+          checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
       print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
 safe-outputs:
   create-pull-request:

--- a/.github/workflows/gh-aw-fragments/safe-output-push-to-pr.md
+++ b/.github/workflows/gh-aw-fragments/safe-output-push-to-pr.md
@@ -36,6 +36,7 @@ safe-inputs:
 
       contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
       pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+      agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
       # Generate diff of all local changes vs upstream for self-review
       # Try --merge-base (vs common ancestor), fall back to
       # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -59,18 +60,84 @@ safe-inputs:
           if result.stdout.strip():
               stat_text = result.stdout.strip()
               break
+      # Capture commit messages so the sub-agent knows what changed and why
+      commits_text = ''
+      for log_cmd in [
+          ['git', 'log', '--format=### %s%n%n%b', '@{upstream}..HEAD'],
+          ['git', 'log', '--format=### %s%n%n%b', '-10'],
+      ]:
+          result = run(log_cmd)
+          if result.stdout.strip():
+              commits_text = result.stdout.strip()
+              break
       os.makedirs('/tmp/self-review', exist_ok=True)
       with open('/tmp/self-review/diff.patch', 'w') as f:
           f.write(diff_text)
       with open('/tmp/self-review/stat.txt', 'w') as f:
           f.write(stat_text)
+      with open('/tmp/self-review/commits.txt', 'w') as f:
+          f.write(commits_text)
+      # Copy task context if available (PR metadata from the pr-context step)
+      has_task = False
+      if os.path.isfile('/tmp/pr-context/pr.json'):
+          import shutil
+          shutil.copy('/tmp/pr-context/pr.json', '/tmp/self-review/task.json')
+          has_task = True
+      # Write manifest so the sub-agent has structured context without
+      # relying on the main agent to manually pass it in the prompt
+      manifest_lines = [
+          '# Self-Review Context',
+          '',
+          'You are reviewing unpushed changes before they are submitted to a PR.',
+          '',
+          '## Available files',
+          '',
+          'All files are in `/tmp/self-review/`:',
+          '',
+          f'- `diff.patch` : Full unified diff of all changes ({len(diff_text.splitlines())} lines)',
+          '- `stat.txt` : File-level change summary',
+          '- `commits.txt` : Commit messages describing what was changed and why',
+          '- `notes.md` : Author notes on what was done, why, and key decisions made',
+      ]
+      if has_task:
+          manifest_lines.append('- `task.json` : Original PR context (title, body, author, branches)')
+      step = 1
+      manifest_lines += ['', '## How to review', '']
+      manifest_lines.append(f'{step}. Read `notes.md` to understand what the author did, why, and what decisions they made.')
+      step += 1
+      manifest_lines.append(f'{step}. Read `commits.txt` for the commit-level view of what changed.')
+      step += 1
+      if has_task:
+          manifest_lines.append(f'{step}. Read `task.json` to understand the original task or issue being addressed.')
+          step += 1
+      manifest_lines.append(f'{step}. Read `stat.txt` for a high-level view of which files changed.')
+      step += 1
+      manifest_lines.append(f'{step}. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).')
+      step += 1
+      if agents_md:
+          manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+      manifest_lines += [
+          '',
+          '## Focus areas',
+          '',
+          'Look for bugs, logic errors, missed edge cases, and style issues.',
+          'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+          '',
+          '## What NOT to flag',
+          '',
+          '- Pre-existing issues not introduced by these changes',
+          '- Style preferences handled by linters or formatters',
+          '- Theoretical performance concerns without evidence of real-world impact',
+      ]
+      with open('/tmp/self-review/README.md', 'w') as f:
+          f.write('\n'.join(manifest_lines) + '\n')
       diff_line_count = len(diff_text.splitlines())
       checklist = []
       if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
       if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
       checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
       if diff_line_count > 0:
-          checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again to regenerate the diff before proceeding.')
+          checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again.')
       print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
 safe-outputs:
   push-to-pull-request-branch:

--- a/.github/workflows/gh-aw-issue-fixer.lock.yml
+++ b/.github/workflows/gh-aw-issue-fixer.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"041435fe5acc257c775e905b4654e3dc106d09d87abc5beabb20658125f901b6"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"b049116d1b44954deb1d6fd4735689d11fdb16abe08af4b4b1a5cc7260343d9e"}
 
 name: "Issue Fixer"
 "on":
@@ -994,6 +994,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -1017,18 +1018,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-mention-in-issue-no-sandbox.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-issue-no-sandbox.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"2f29669456d66cae2aa4f8c35dc0a00fd43581d7e16e8dc74164a2c56c98c938"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"e722c1c71a5f085fd900a4da5efd5b418919aff123514bfdc9dd6e373fd0e2d9"}
 
 name: "Mention in Issue (no sandbox)"
 "on":
@@ -1088,6 +1088,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -1111,18 +1112,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-mention-in-issue.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"772804e26202b254644eb819d08f00f2100e9e98d825548abc53be197fbaa1cd"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"6f6a0093b731fadbf56e960e738e5198d3a3b561f3167524ed8399cd7163106f"}
 
 name: "Mention in Issue"
 "on":
@@ -1092,6 +1092,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -1115,18 +1116,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-mention-in-pr-by-id.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-pr-by-id.lock.yml
@@ -43,7 +43,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"c1596c1d583a1d00154c0d46ffeb93694bd2f8cd2568fa0b0669f1e76848d4b3"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"6d4152d2e4782ed202c539121d0370f9cedcf1bad67f7e8361a984c5c0fa8c8e"}
 
 name: "Mention in PR by ID"
 "on":
@@ -1250,6 +1250,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -1273,18 +1274,84 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', '@{upstream}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Copy task context if available (PR metadata from the pr-context step)
+          has_task = False
+          if os.path.isfile('/tmp/pr-context/pr.json'):
+              import shutil
+              shutil.copy('/tmp/pr-context/pr.json', '/tmp/self-review/task.json')
+              has_task = True
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted to a PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({len(diff_text.splitlines())} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+          ]
+          if has_task:
+              manifest_lines.append('- `task.json` : Original PR context (title, body, author, branches)')
+          step = 1
+          manifest_lines += ['', '## How to review', '']
+          manifest_lines.append(f'{step}. Read `notes.md` to understand what the author did, why, and what decisions they made.')
+          step += 1
+          manifest_lines.append(f'{step}. Read `commits.txt` for the commit-level view of what changed.')
+          step += 1
+          if has_task:
+              manifest_lines.append(f'{step}. Read `task.json` to understand the original task or issue being addressed.')
+              step += 1
+          manifest_lines.append(f'{step}. Read `stat.txt` for a high-level view of which files changed.')
+          step += 1
+          manifest_lines.append(f'{step}. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).')
+          step += 1
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           diff_line_count = len(diff_text.splitlines())
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-mention-in-pr-no-sandbox.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-pr-no-sandbox.lock.yml
@@ -44,7 +44,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"b8f87b805cb8e2d0dabcb69a1a14c5bfe167f537bbf66deda2f051163a3bbb21"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"df91e320ec660e442d65ff1a17f5c9467ebcc66175aa4ca2b59661d126eeba33"}
 
 name: "Mention in PR (no sandbox)"
 "on":
@@ -1346,6 +1346,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -1369,18 +1370,84 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', '@{upstream}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Copy task context if available (PR metadata from the pr-context step)
+          has_task = False
+          if os.path.isfile('/tmp/pr-context/pr.json'):
+              import shutil
+              shutil.copy('/tmp/pr-context/pr.json', '/tmp/self-review/task.json')
+              has_task = True
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted to a PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({len(diff_text.splitlines())} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+          ]
+          if has_task:
+              manifest_lines.append('- `task.json` : Original PR context (title, body, author, branches)')
+          step = 1
+          manifest_lines += ['', '## How to review', '']
+          manifest_lines.append(f'{step}. Read `notes.md` to understand what the author did, why, and what decisions they made.')
+          step += 1
+          manifest_lines.append(f'{step}. Read `commits.txt` for the commit-level view of what changed.')
+          step += 1
+          if has_task:
+              manifest_lines.append(f'{step}. Read `task.json` to understand the original task or issue being addressed.')
+              step += 1
+          manifest_lines.append(f'{step}. Read `stat.txt` for a high-level view of which files changed.')
+          step += 1
+          manifest_lines.append(f'{step}. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).')
+          step += 1
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           diff_line_count = len(diff_text.splitlines())
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-mention-in-pr.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-pr.lock.yml
@@ -44,7 +44,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"93982cd9e65d497aa1db1b9215850ab8773b3d6bcd4c01af401cef6e4059b706"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"95302ccffa65ba0db480f26ae1e7941b73d43d8850ed1f043520bf4518c6c6b8"}
 
 name: "Mention in PR"
 "on":
@@ -1376,6 +1376,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -1399,18 +1400,84 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', '@{upstream}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Copy task context if available (PR metadata from the pr-context step)
+          has_task = False
+          if os.path.isfile('/tmp/pr-context/pr.json'):
+              import shutil
+              shutil.copy('/tmp/pr-context/pr.json', '/tmp/self-review/task.json')
+              has_task = True
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted to a PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({len(diff_text.splitlines())} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+          ]
+          if has_task:
+              manifest_lines.append('- `task.json` : Original PR context (title, body, author, branches)')
+          step = 1
+          manifest_lines += ['', '## How to review', '']
+          manifest_lines.append(f'{step}. Read `notes.md` to understand what the author did, why, and what decisions they made.')
+          step += 1
+          manifest_lines.append(f'{step}. Read `commits.txt` for the commit-level view of what changed.')
+          step += 1
+          if has_task:
+              manifest_lines.append(f'{step}. Read `task.json` to understand the original task or issue being addressed.')
+              step += 1
+          manifest_lines.append(f'{step}. Read `stat.txt` for a high-level view of which files changed.')
+          step += 1
+          manifest_lines.append(f'{step}. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).')
+          step += 1
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           diff_line_count = len(diff_text.splitlines())
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-newbie-contributor-fixer.lock.yml
+++ b/.github/workflows/gh-aw-newbie-contributor-fixer.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"68fe3955d7336a38fb15e42984184eb4645dd94a675b927ceed251e3371190c2"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"668455559a79bcaa71d52c9042ce5d548470939e3bc60820b6f09d82f3bf7576"}
 
 name: "Newbie Contributor Fixer"
 "on":
@@ -941,6 +941,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -964,18 +965,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-pr-actions-fixer.lock.yml
+++ b/.github/workflows/gh-aw-pr-actions-fixer.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"298b77fb909370a57fe73a3b3bbaabfbd71ca475536eda404975e44f38ab7fa1"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"08b813feb96862e82170249f6c6d7cd556895b7e1ba077737c3f7a775e3b7a53"}
 
 name: "PR Actions Fixer"
 "on":
@@ -960,6 +960,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -983,18 +984,84 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', '@{upstream}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Copy task context if available (PR metadata from the pr-context step)
+          has_task = False
+          if os.path.isfile('/tmp/pr-context/pr.json'):
+              import shutil
+              shutil.copy('/tmp/pr-context/pr.json', '/tmp/self-review/task.json')
+              has_task = True
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted to a PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({len(diff_text.splitlines())} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+          ]
+          if has_task:
+              manifest_lines.append('- `task.json` : Original PR context (title, body, author, branches)')
+          step = 1
+          manifest_lines += ['', '## How to review', '']
+          manifest_lines.append(f'{step}. Read `notes.md` to understand what the author did, why, and what decisions they made.')
+          step += 1
+          manifest_lines.append(f'{step}. Read `commits.txt` for the commit-level view of what changed.')
+          step += 1
+          if has_task:
+              manifest_lines.append(f'{step}. Read `task.json` to understand the original task or issue being addressed.')
+              step += 1
+          manifest_lines.append(f'{step}. Read `stat.txt` for a high-level view of which files changed.')
+          step += 1
+          manifest_lines.append(f'{step}. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).')
+          step += 1
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           diff_line_count = len(diff_text.splitlines())
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-pr-review-addresser.lock.yml
+++ b/.github/workflows/gh-aw-pr-review-addresser.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"e14207a7410bee2f30a37e655d590e23de4f5a211b2f562a06622289c3b028b2"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"09978e81da842ac2a86b1f66b69cfe315f50f46d6da032b6eb857cae510f3d3b"}
 
 name: "PR Review Addresser"
 "on":
@@ -1069,6 +1069,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -1092,18 +1093,84 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', '@{upstream}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Copy task context if available (PR metadata from the pr-context step)
+          has_task = False
+          if os.path.isfile('/tmp/pr-context/pr.json'):
+              import shutil
+              shutil.copy('/tmp/pr-context/pr.json', '/tmp/self-review/task.json')
+              has_task = True
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted to a PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({len(diff_text.splitlines())} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+          ]
+          if has_task:
+              manifest_lines.append('- `task.json` : Original PR context (title, body, author, branches)')
+          step = 1
+          manifest_lines += ['', '## How to review', '']
+          manifest_lines.append(f'{step}. Read `notes.md` to understand what the author did, why, and what decisions they made.')
+          step += 1
+          manifest_lines.append(f'{step}. Read `commits.txt` for the commit-level view of what changed.')
+          step += 1
+          if has_task:
+              manifest_lines.append(f'{step}. Read `task.json` to understand the original task or issue being addressed.')
+              step += 1
+          manifest_lines.append(f'{step}. Read `stat.txt` for a high-level view of which files changed.')
+          step += 1
+          manifest_lines.append(f'{step}. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).')
+          step += 1
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           diff_line_count = len(diff_text.splitlines())
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_push_to_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-release-update.lock.yml
+++ b/.github/workflows/gh-aw-release-update.lock.yml
@@ -36,7 +36,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"8cd4174059c7370c709de611a34239bf5b5af6aa8ea6dd50de69e299931220fa"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"bfa86aa31b4e6f0a870f7c18e438b0134675b3efddc5d2213a4e78e3e4e037c6"}
 
 name: "Release Update Check"
 "on":
@@ -909,6 +909,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -932,18 +933,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-scheduled-fix.lock.yml
+++ b/.github/workflows/gh-aw-scheduled-fix.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"386b2f77664c20e0bd3cd6d6f486eb64e82a0470c451eba15f0bb4a2ace09abd"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"bffc9dc9b2e0ab4ba3fd0e07a75e52995fa1af1a854e304d7bbee5eef75678dd"}
 
 name: "Scheduled Fix"
 "on":
@@ -964,6 +964,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -987,18 +988,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-small-problem-fixer.lock.yml
+++ b/.github/workflows/gh-aw-small-problem-fixer.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"e15b4d9e7e0121fc261ec5f1e8067b612ab404f0fe5e71859f01c41f7b9475f6"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"142bcd3b6f889b8b153aa8a9d44df18005d036e716d2afb0cf217f3fa08d9504"}
 
 name: "Small Problem Fixer"
 "on":
@@ -998,6 +998,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -1021,18 +1022,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-test-improvement.lock.yml
+++ b/.github/workflows/gh-aw-test-improvement.lock.yml
@@ -41,7 +41,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"1b55c6bcc09d69a69075ad5bfc9f79977b9e25b8b43ee87eb2559ea136b82a39"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"246e3e183218a73daca6a54d125c0a4b4857c25ec725e5d9cc7a57072f24cd73"}
 
 name: "Test Improver"
 "on":
@@ -952,6 +952,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -975,18 +976,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-test-improver.lock.yml
+++ b/.github/workflows/gh-aw-test-improver.lock.yml
@@ -36,7 +36,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"1b55c6bcc09d69a69075ad5bfc9f79977b9e25b8b43ee87eb2559ea136b82a39"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"246e3e183218a73daca6a54d125c0a4b4857c25ec725e5d9cc7a57072f24cd73"}
 
 name: "Test Improver"
 "on":
@@ -947,6 +947,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -970,18 +971,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/.github/workflows/gh-aw-text-beautifier.lock.yml
+++ b/.github/workflows/gh-aw-text-beautifier.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"e3ddec0bc3ac021ea321ab3aeb3565b43497ff5e1c03d845bfc5f42ce983e57a"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"9d3dc1b0069393eae652e0eeb1af9a89f52ba1d1e74c7af019b7e5ee5f7d4964"}
 
 name: "Text Beautifier"
 "on":
@@ -949,6 +949,7 @@ jobs:
           
           contributing = find('CONTRIBUTING.md', 'CONTRIBUTING.rst', 'docs/CONTRIBUTING.md', 'docs/contributing.md')
           pr_template = find('.github/pull_request_template.md', '.github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md')
+          agents_md = find('AGENTS.md', 'agents.md', '.github/agents.md', '.github/AGENTS.md')
           # Generate diff of all local changes vs upstream for self-review
           # Try --merge-base (vs common ancestor), fall back to
           # @{upstream} 2-dot (vs upstream tip), then HEAD (uncommitted only)
@@ -972,18 +973,71 @@ jobs:
               if result.stdout.strip():
                   stat_text = result.stdout.strip()
                   break
+          # Capture commit messages so the sub-agent knows what changed and why
+          commits_text = ''
+          for log_cmd in [
+              ['git', 'log', '--format=### %s%n%n%b', f'{upstream_sha}..HEAD'],
+              ['git', 'log', '--format=### %s%n%n%b', '-10'],
+          ]:
+              result = run(log_cmd)
+              if result.stdout.strip():
+                  commits_text = result.stdout.strip()
+                  break
           os.makedirs('/tmp/self-review', exist_ok=True)
           with open('/tmp/self-review/diff.patch', 'w') as f:
               f.write(diff_text)
           with open('/tmp/self-review/stat.txt', 'w') as f:
               f.write(stat_text)
+          with open('/tmp/self-review/commits.txt', 'w') as f:
+              f.write(commits_text)
+          # Write manifest so the sub-agent has structured context without
+          # relying on the main agent to manually pass it in the prompt
           diff_line_count = len(diff_text.splitlines())
+          manifest_lines = [
+              '# Self-Review Context',
+              '',
+              'You are reviewing unpushed changes before they are submitted as a new PR.',
+              '',
+              '## Available files',
+              '',
+              'All files are in `/tmp/self-review/`:',
+              '',
+              f'- `diff.patch` : Full unified diff of all changes ({diff_line_count} lines)',
+              '- `stat.txt` : File-level change summary',
+              '- `commits.txt` : Commit messages describing what was changed and why',
+              '- `notes.md` : Author notes on what was done, why, and key decisions made',
+              '',
+              '## How to review',
+              '',
+              '1. Read `notes.md` to understand what the author did, why, and what decisions they made.',
+              '2. Read `commits.txt` for the commit-level view of what changed.',
+              '3. Read `stat.txt` for a high-level view of which files changed.',
+              '4. Read `diff.patch` and the relevant source files from the workspace (the branch is checked out).',
+          ]
+          step = 5
+          if agents_md:
+              manifest_lines.append(f'{step}. Read `{agents_md}` in the workspace for repository coding conventions.')
+          manifest_lines += [
+              '',
+              '## Focus areas',
+              '',
+              'Look for bugs, logic errors, missed edge cases, and style issues.',
+              'Focus on what the author might have MISSED rather than re-deriving their reasoning.',
+              '',
+              '## What NOT to flag',
+              '',
+              '- Pre-existing issues not introduced by these changes',
+              '- Style preferences handled by linters or formatters',
+              '- Theoretical performance concerns without evidence of real-world impact',
+          ]
+          with open('/tmp/self-review/README.md', 'w') as f:
+              f.write('\n'.join(manifest_lines) + '\n')
           checklist = []
           if contributing: checklist.append(f'Review the contributing guide ({contributing}) before opening or updating a PR.')
           if pr_template: checklist.append(f'Follow the PR template ({pr_template}) for title, description, and validation notes.')
           checklist.append('Confirm the requested task is fully completed and validated before creating or pushing PR changes.')
           if diff_line_count > 0:
-              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) has been saved to `/tmp/self-review/diff.patch` (full diff) and `/tmp/self-review/stat.txt` (summary). Spawn a `code-review` sub-agent via `runSubagent` to review the diff against the codebase. Tell it to read `/tmp/self-review/diff.patch` and the relevant source files, and look for bugs, logic errors, missed edge cases, and style issues. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again to regenerate the diff before proceeding.')
+              checklist.append(f'A diff of your unpushed changes ({diff_line_count} lines) and supporting context have been saved to `/tmp/self-review/`. Before spawning the sub-agent, write `/tmp/self-review/notes.md` with: what you changed and why, which files matter most and what they do, edge cases you already handled, and what test coverage exists. Then spawn a `code-review` sub-agent via `runSubagent` and tell it to start by reading `/tmp/self-review/README.md`. If the sub-agent finds legitimate issues, fix them, commit, and call `ready_to_make_pr` again.')
           print(json.dumps({'status': 'ok', 'checklist': checklist, 'contributing_guide': contributing, 'pr_template': pr_template, 'diff_line_count': diff_line_count}))
           
           

--- a/tests/test_safe_input_ready_to_make_pr.py
+++ b/tests/test_safe_input_ready_to_make_pr.py
@@ -286,6 +286,34 @@ class TestFileOutput:
         assert Path("/tmp/self-review/diff.patch").read_text() == ""
         assert Path("/tmp/self-review/stat.txt").read_text() == ""
 
+    def test_commits_txt_created(self, py_code, tmp_path):
+        """commits.txt should capture commit messages since upstream."""
+        repo = make_git_repo(tmp_path, with_upstream=True)
+        (repo / "new.txt").write_text("new\n")
+        subprocess.run(["git", "add", "new.txt"], cwd=str(repo), check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add new feature"],
+            cwd=str(repo), check=True, capture_output=True,
+        )
+
+        run_py_in_repo(py_code, str(repo))
+
+        commits = Path("/tmp/self-review/commits.txt").read_text()
+        assert "add new feature" in commits
+
+    def test_readme_manifest_created(self, py_code, tmp_path):
+        """README.md manifest should be created with review instructions."""
+        repo = make_git_repo(tmp_path, with_upstream=True)
+        (repo / "file.txt").write_text("modified\n")
+
+        run_py_in_repo(py_code, str(repo))
+
+        readme = Path("/tmp/self-review/README.md").read_text()
+        assert "Self-Review Context" in readme
+        assert "diff.patch" in readme
+        assert "commits.txt" in readme
+        assert "notes.md" in readme
+
 
 # ---------------------------------------------------------------------------
 # Contributing / PR template detection
@@ -356,7 +384,7 @@ class TestSelfReviewGating:
         output = run_py_in_repo(py_code, str(repo))
         checklist_text = " ".join(output["checklist"])
         assert "self-review" in checklist_text
-        assert "diff.patch" in checklist_text
+        assert "README.md" in checklist_text
 
     def test_self_review_absent_when_no_diff(self, py_code, tmp_path):
         repo = make_git_repo(tmp_path, with_upstream=True)


### PR DESCRIPTION
## Summary

- Replaces the prompt-only approach from PR #509 with structured context files written to `/tmp/self-review/`
- Automatically captures `commits.txt` (git log since upstream) for self-review context
- In `ready_to_push_to_pr`, copies `task.json` from `/tmp/pr-context/pr.json` when available
- Instructs the main agent to write `notes.md` with implementation context before spawning the sub-agent
- Generates a `README.md` manifest with review instructions, and tells the sub-agent to start there
- Adds an `AGENTS.md` convention step in the manifest when that file exists
- Mirrors the rich context system the PR review workflow already uses via `/tmp/pr-context/`

## Context

When the main agent calls `ready_to_push_to_pr` or `ready_to_make_pr`, a self-review sub-agent is spawned to review the diff. Previously, the sub-agent started cold with only `diff.patch` and `stat.txt` — no idea what the task was or why changes were made.

PR #509 tried to fix this by adding a text instruction asking the agent to "include context in your prompt." This is unreliable (the agent might not do it) and wastes main-agent tokens generating context that can be captured automatically.

This PR solves it structurally:

| File | Source | Purpose |
|------|--------|---------|
| `commits.txt` | Auto (git log) | What changed, commit by commit |
| `task.json` | Auto when available (copied from `/tmp/pr-context/pr.json` in `ready_to_push_to_pr`) | Original PR/issue context |
| `notes.md` | Agent writes before spawning | Intent, key files, edge cases, test coverage |
| `README.md` | Auto (generated manifest) | Tells sub-agent what to read and how to review |

## Test plan

- [x] All 32 existing tests pass (including 2 new tests for `commits.txt` and `README.md`)
- [x] `make compile` succeeds — all 19 lock files updated
- [ ] Verify in a real workflow run that the sub-agent reads the context files

🤖 Generated with [Claude Code]((claude.com/redacted)

> Generated by [Update PR Body](https://github.com/elastic/ai-github-actions/actions/runs/22534684527) for issue #511

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22534684527, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions/actions/runs/22534684527 -->