### PR TITLE
Fix remediation trigger permission boundary for create-pr workflow

### DIFF
--- a/.github/workflows/gh-aw-create-pr-from-issue.lock.yml
+++ b/.github/workflows/gh-aw-create-pr-from-issue.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e18e4136ec2c2555f2949ff3d20a46828f6ff0aea05e719cec9de72a66e9e3f3"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"612ea26f3ac3cb54a9fb9279b2a60a10eec6cfcdd9201440a3ac36cec4cb1e1e"}
 
 name: "Create PR From Issue"
 "on":
@@ -1552,7 +1552,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     concurrency:
@@ -1694,7 +1693,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15

--- a/.github/workflows/gh-aw-create-pr-from-issue.md
+++ b/.github/workflows/gh-aw-create-pr-from-issue.md
@@ -79,6 +79,10 @@ safe-outputs:
   activation-comments: false
   max-patch-size: 10240
   add-comment:
+    max: 1
+    pull-requests: false
+    issues: true
+    discussions: false
     target: "${{ inputs.target-issue-number }}"
 timeout-minutes: 60
 steps:

--- a/.github/workflows/trigger-docs-patrol.yml
+++ b/.github/workflows/trigger-docs-patrol.yml
@@ -11,6 +11,7 @@ permissions:
   issues: write
   pull-requests: write
 
+  actions: read
 jobs:
   run:
     uses: ./.github/workflows/gh-aw-docs-patrol.lock.yml

--- a/.github/workflows/trigger-framework-best-practices.yml
+++ b/.github/workflows/trigger-framework-best-practices.yml
@@ -11,6 +11,7 @@ permissions:
   issues: write
   pull-requests: write
 
+  actions: read
 jobs:
   run:
     uses: ./.github/workflows/gh-aw-framework-best-practices.lock.yml

--- a/.github/workflows/trigger-text-auditor.yml
+++ b/.github/workflows/trigger-text-auditor.yml
@@ -11,6 +11,7 @@ permissions:
   issues: write
   pull-requests: write
 
+  actions: read
 jobs:
   run:
     uses: ./.github/workflows/gh-aw-text-auditor.lock.yml

--- a/scripts/dogfood.sh
+++ b/scripts/dogfood.sh
@@ -110,8 +110,28 @@ for f in gh-agent-workflows/*/example.yml; do
     [[ "$dir" == "$remediation" ]] && add_remediation=true && break
   done
   if [[ "$add_remediation" == "true" ]]; then
-    # Ensure permissions allow downstream PR creation job.
-    sed -E 's/^([[:space:]]*contents: )read$/\1write/; s/^([[:space:]]*pull-requests: )read$/\1write/' "$target" > "$target.tmp" && mv "$target.tmp" "$target"
+    # Ensure permissions allow downstream remediation workflow call.
+    awk '
+      BEGIN { in_permissions=0; have_actions=0 }
+      /^permissions:/ { in_permissions=1; print; next }
+      in_permissions {
+        if (/^jobs:/) {
+          if (!have_actions) print "  actions: read"
+          in_permissions=0
+          print
+          next
+        }
+        if ($0 ~ /^  contents: /) sub(/read$/, "write")
+        if ($0 ~ /^  pull-requests: /) sub(/read$/, "write")
+        if ($0 ~ /^  actions: /) {
+          if ($0 ~ /none$/) sub(/none$/, "read")
+          have_actions=1
+        }
+        print
+        next
+      }
+      { print }
+    ' "$target" > "$target.tmp" && mv "$target.tmp" "$target"
 
     cat >> "$target" <<'EOF'
 


### PR DESCRIPTION
## Summary
- update `scripts/dogfood.sh` remediation generation logic so trigger workflows chained to `gh-aw-create-pr-from-issue` always include `actions: read` at top-level `permissions`, while still elevating `contents`/`pull-requests` to `write`
- restore explicit issue-only safe-output `add-comment` settings in `.github/workflows/gh-aw-create-pr-from-issue.md` (`max: 1`, `issues: true`, `pull-requests: false`, `discussions: false`)
- regenerate the affected workflow outputs: `.github/workflows/trigger-text-auditor.yml`, `.github/workflows/trigger-docs-patrol.yml`, `.github/workflows/trigger-framework-best-practices.yml`, and `.github/workflows/gh-aw-create-pr-from-issue.lock.yml`

## Test plan
- [x] `make compile`
- [x] `make lint-workflows`
- [x] verified generated remediation trigger workflows include `actions: read`
- [x] verified generated `.github/workflows/gh-aw-create-pr-from-issue.lock.yml` safe-output jobs no longer request `discussions: write` permissions

---
The body of this PR [is automatically managed](https://ela.st/github-ai-tools) by the [Trigger Update PR Body workflow](https://github.com/elastic/ai-github-actions/actions/runs/22816903746).

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22816903746, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions/actions/runs/22816903746 -->