### PR TITLE
Bring detective noop-on-no-failure changes onto updated branch

### DIFF
--- a/.github/workflows/gh-aw-branch-actions-detective.lock.yml
+++ b/.github/workflows/gh-aw-branch-actions-detective.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4050fcb0c028d6ebec3e50c5a46c9f8189c5b5d4615d9adef8fa0782d94c5df6"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"037ad0e086399f3111e9f30bf618a7ef973f234a214024c9bc22412acbfcfa9a"}
 
 name: "Branch Actions Detective"
 "on":
@@ -339,6 +339,7 @@ jobs:
                gh api repos/__GH_AW_GITHUB_REPOSITORY__/actions/runs/{run_id}/jobs \
                  --jq '.jobs[] | {id: .id, name: .name, conclusion: .conclusion, html_url: .html_url}'
                ````
+             - If none of the jobs have a `failure` conclusion, call `noop` with message "No failed jobs in workflow run; nothing to report" and stop.
              - Download logs to `/tmp/gh-aw/agent/` and inspect the failing step output:
                ````bash
                gh api repos/__GH_AW_GITHUB_REPOSITORY__/actions/runs/{run_id}/logs \

--- a/.github/workflows/gh-aw-branch-actions-detective.md
+++ b/.github/workflows/gh-aw-branch-actions-detective.md
@@ -111,6 +111,7 @@ Analyze failed GitHub Actions CI runs on protected branches (e.g. `main`) in ${{
      gh api repos/${{ github.repository }}/actions/runs/{run_id}/jobs \
        --jq '.jobs[] | {id: .id, name: .name, conclusion: .conclusion, html_url: .html_url}'
      ````
+   - If none of the jobs have a `failure` conclusion, call `noop` with message "No failed jobs in workflow run; nothing to report" and stop.
    - Download logs to `/tmp/gh-aw/agent/` and inspect the failing step output:
      ````bash
      gh api repos/${{ github.repository }}/actions/runs/{run_id}/logs \

--- a/.github/workflows/gh-aw-pr-actions-detective.lock.yml
+++ b/.github/workflows/gh-aw-pr-actions-detective.lock.yml
@@ -36,7 +36,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6a6e07c4afd1b88685f43eab8c0a9b1a87f6fa6bfa0e03dabddd23f692d43d73"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ceb846fce83602bfa5f707bc6793ccabfd0b2cb039ae17a95ad8218a3b4fe525"}
 
 name: "PR Actions Detective"
 "on":
@@ -325,6 +325,7 @@ jobs:
                gh api repos/__GH_AW_GITHUB_REPOSITORY__/actions/runs/{run_id}/jobs \
                  --jq '.jobs[] | {id: .id, name: .name, conclusion: .conclusion, html_url: .html_url}'
               ```
+             - If none of the jobs have a `failure` conclusion, call `noop` with message "No failed jobs in workflow run; nothing to report" and stop.
              - Download logs to `/tmp/gh-aw/agent/` and inspect the failing step output:
               ```bash
                gh api repos/__GH_AW_GITHUB_REPOSITORY__/actions/runs/{run_id}/logs \

--- a/.github/workflows/gh-aw-pr-actions-detective.md
+++ b/.github/workflows/gh-aw-pr-actions-detective.md
@@ -102,6 +102,7 @@ Assist with failed GitHub Actions checks for pull requests in ${{ github.reposit
      gh api repos/${{ github.repository }}/actions/runs/{run_id}/jobs \
        --jq '.jobs[] | {id: .id, name: .name, conclusion: .conclusion, html_url: .html_url}'
     ```
+   - If none of the jobs have a `failure` conclusion, call `noop` with message "No failed jobs in workflow run; nothing to report" and stop.
    - Download logs to `/tmp/gh-aw/agent/` and inspect the failing step output:
     ```bash
      gh api repos/${{ github.repository }}/actions/runs/{run_id}/logs \

--- a/.github/workflows/gh-aw-pr-ci-detective.lock.yml
+++ b/.github/workflows/gh-aw-pr-ci-detective.lock.yml
@@ -41,7 +41,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6a6e07c4afd1b88685f43eab8c0a9b1a87f6fa6bfa0e03dabddd23f692d43d73"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ceb846fce83602bfa5f707bc6793ccabfd0b2cb039ae17a95ad8218a3b4fe525"}
 
 name: "PR Actions Detective"
 "on":
@@ -330,6 +330,7 @@ jobs:
                gh api repos/__GH_AW_GITHUB_REPOSITORY__/actions/runs/{run_id}/jobs \
                  --jq '.jobs[] | {id: .id, name: .name, conclusion: .conclusion, html_url: .html_url}'
               ```
+             - If none of the jobs have a `failure` conclusion, call `noop` with message "No failed jobs in workflow run; nothing to report" and stop.
              - Download logs to `/tmp/gh-aw/agent/` and inspect the failing step output:
               ```bash
                gh api repos/__GH_AW_GITHUB_REPOSITORY__/actions/runs/{run_id}/logs \

--- a/gh-agent-workflows/branch-actions-detective/README.md
+++ b/gh-agent-workflows/branch-actions-detective/README.md
@@ -33,3 +33,4 @@ See [example.yml](example.yml) for the full workflow file.
 ## Safe Outputs
 
 - `create-issue` — file a tracking issue for the CI failure (max 1, auto-closes older issues)
+- `noop` — emitted when no failed jobs are found or failure already tracked by an open issue

--- a/gh-agent-workflows/pr-actions-detective/README.md
+++ b/gh-agent-workflows/pr-actions-detective/README.md
@@ -33,3 +33,4 @@ See [example.yml](example.yml) for the full workflow file.
 ## Safe Outputs
 
 - `add-comment` — post a comment explaining the failure (max 3)
+- `noop` — emitted when no failed jobs are found or diagnosis unchanged since last report


### PR DESCRIPTION
## Summary
- Merge the detective workflow updates from PR #606 into this branch.
- Keep the branch updated with latest `origin/main` and preserve regenerated detective lockfiles.
- Include the prompt/README behavior where detective workflows explicitly `noop` when no jobs are failing.

## Test plan
- [x] `make compile`

Made with [Cursor](https://cursor.com)