### PR TITLE
Add include/exclude label filters to conflicted PR action

### DIFF
--- a/.github/actions/get-prs-with-merge-conflicts/action.yml
+++ b/.github/actions/get-prs-with-merge-conflicts/action.yml
@@ -9,8 +9,16 @@ inputs:
     description: "Seconds to wait before checking merge conflict state"
     required: false
     default: "60"
+  include-labels:
+    description: "Only include PRs that have at least one of these labels (comma-separated). Empty means no include filter."
+    required: false
+    default: ""
+  exclude-labels:
+    description: "Exclude PRs that have any of these labels (comma-separated)."
+    required: false
+    default: ""
   opt-out-label:
-    description: "Skip PRs with this label"
+    description: "Deprecated: exclude PRs with this label (kept for backward compatibility)"
     required: false
     default: "no-address-merge-conflicts"
 
@@ -38,7 +46,19 @@ runs:
         github-token: ${{ inputs.github-token }}
         script: |
           const [owner, repo] = process.env.REPOSITORY.split("/");
-          const optOutLabel = core.getInput("opt-out-label");
+          const parseLabelSet = (input) =>
+            new Set(
+              input
+                .split(",")
+                .map((label) => label.trim().toLowerCase())
+                .filter((label) => label.length > 0),
+            );
+          const includeLabels = parseLabelSet(core.getInput("include-labels"));
+          const excludeLabels = parseLabelSet(core.getInput("exclude-labels"));
+          const optOutLabel = core.getInput("opt-out-label").trim().toLowerCase();
+          if (optOutLabel) {
+            excludeLabels.add(optOutLabel);
+          }
           const result = await github.graphql(
             `query($owner: String!, $repo: String!) {
               repository(owner: $owner, name: $repo) {
@@ -59,14 +79,18 @@ runs:
 
           const prs = [];
           for (const pr of result.repository.pullRequests.nodes) {
-            const labels = new Set((pr.labels?.nodes ?? []).map((l) => l.name));
-            const optedIn = !labels.has(optOutLabel);
+            const labels = new Set((pr.labels?.nodes ?? []).map((l) => l.name.toLowerCase()));
+            const matchesInclude =
+              includeLabels.size === 0 || [...includeLabels].some((label) => labels.has(label));
+            const matchesExclude = [...excludeLabels].some((label) => labels.has(label));
             const conflicted = pr.mergeStateStatus === "DIRTY";
-            if (!pr.isDraft && optedIn && conflicted) {
+            if (!pr.isDraft && matchesInclude && !matchesExclude && conflicted) {
               prs.push({ number: pr.number });
             }
           }
 
-          core.info(`Found ${prs.length} conflicted PR(s) without opt-out label '${optOutLabel}'.`);
+          core.info(
+            `Found ${prs.length} conflicted PR(s). includeLabels=${JSON.stringify([...includeLabels])}, excludeLabels=${JSON.stringify([...excludeLabels])}`,
+          );
           core.setOutput("prs", JSON.stringify(prs));
           core.setOutput("count", String(prs.length));


### PR DESCRIPTION
## Summary
- Add `include-labels` and `exclude-labels` inputs to `.github/actions/get-prs-with-merge-conflicts`.
- Keep `opt-out-label` as a deprecated, backward-compatible exclusion that is merged into `exclude-labels`.
- Preserve existing outputs (`prs`, `count`) and conflict detection behavior.
- Normalize configured labels and PR label names to lowercase, making include/exclude matching case-insensitive.

## Test plan
- Validate action YAML parses and passes lint checks.
- Verify label normalization and include/exclude filtering logic in the `github-script` step.

---
The body of this PR [is automatically managed](https://ela.st/github-ai-tools) by the [Trigger Update PR Body workflow](https://github.com/elastic/ai-github-actions/actions/runs/22835545957).

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22835545957, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions/actions/runs/22835545957 -->