### PR TITLE
Filter conflicted PRs by author association to exclude external contributors

### DIFF
--- a/.github/actions/get-prs-with-merge-conflicts/action.yml
+++ b/.github/actions/get-prs-with-merge-conflicts/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ""
   author-associations:
-    description: "Only include PRs whose author has one of these associations (comma-separated). Empty means no filter. Values: OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE."
+    description: "Only include PRs whose author has one of these associations (comma-separated). Bot authors (login ending in [bot]) are always allowed. Empty means no filter. Values: OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE."
     required: false
     default: "OWNER,MEMBER,COLLABORATOR"
   opt-out-label:
@@ -82,6 +82,7 @@ runs:
                     isDraft
                     mergeStateStatus
                     authorAssociation
+                    author { login }
                     labels(first: 50) {
                       nodes { name }
                     }
@@ -95,7 +96,7 @@ runs:
           const allPrs = result.repository.pullRequests.nodes;
           core.info(`GraphQL returned ${allPrs.length} open PR(s)`);
           for (const pr of allPrs) {
-            core.info(`  PR #${pr.number}: mergeStateStatus=${pr.mergeStateStatus}, isDraft=${pr.isDraft}, authorAssociation=${pr.authorAssociation}`);
+            core.info(`  PR #${pr.number}: mergeStateStatus=${pr.mergeStateStatus}, isDraft=${pr.isDraft}, author=${pr.author?.login}, authorAssociation=${pr.authorAssociation}`);
           }
 
           const prs = [];
@@ -104,8 +105,9 @@ runs:
             const matchesInclude =
               includeLabels.size === 0 || [...includeLabels].some((label) => labels.has(label));
             const matchesExclude = [...excludeLabels].some((label) => labels.has(label));
+            const isBot = pr.author?.login?.endsWith("[bot]") ?? false;
             const matchesAssociation =
-              allowedAssociations.size === 0 || allowedAssociations.has(pr.authorAssociation);
+              isBot || allowedAssociations.size === 0 || allowedAssociations.has(pr.authorAssociation);
             const conflicted = pr.mergeStateStatus === "DIRTY";
             if (!pr.isDraft && matchesInclude && !matchesExclude && matchesAssociation && conflicted) {
               prs.push({ number: pr.number });


### PR DESCRIPTION
## Summary

- Adds a new `author-associations` input to `.github/actions/get-prs-with-merge-conflicts`.
- Defaults to `OWNER,MEMBER,COLLABORATOR`, so external contributor associations are filtered out by default.
- Fetches `authorAssociation` in the existing GraphQL query and applies the filter alongside the existing draft/label/conflict checks.
- Passing an empty `author-associations` value disables association filtering.

## Test plan

- [ ] Verify conflicted PRs from `OWNER`, `MEMBER`, and `COLLABORATOR` are included.
- [ ] Verify conflicted PRs from `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, and `NONE` are excluded by default.
- [ ] Verify setting `author-associations` to empty disables the association filter.

---
The body of this PR [is automatically managed](https://ela.st/github-ai-tools) by the [Trigger Update PR Body workflow](https://github.com/elastic/ai-github-actions/actions/runs/22836017928).

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22836017928, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions/actions/runs/22836017928 -->