### PR TITLE
Postprocess compiled workflows to use forked gh-aw setup action

### DIFF
--- a/.github/workflows/agent-deep-dive.lock.yml
+++ b/.github/workflows/agent-deep-dive.lock.yml
@@ -79,7 +79,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -528,7 +528,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1310,7 +1310,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1417,7 +1417,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/agent-efficiency.lock.yml
+++ b/.github/workflows/agent-efficiency.lock.yml
@@ -70,7 +70,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -494,7 +494,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1274,7 +1274,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1381,7 +1381,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-agent-suggestions.lock.yml
+++ b/.github/workflows/gh-aw-agent-suggestions.lock.yml
@@ -108,7 +108,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -573,7 +573,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1361,7 +1361,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1451,7 +1451,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1494,7 +1494,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-autonomy-atomicity-analyzer.lock.yml
+++ b/.github/workflows/gh-aw-autonomy-atomicity-analyzer.lock.yml
@@ -108,7 +108,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -577,7 +577,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1365,7 +1365,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1455,7 +1455,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1498,7 +1498,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-branch-actions-detective.lock.yml
+++ b/.github/workflows/gh-aw-branch-actions-detective.lock.yml
@@ -106,7 +106,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -501,7 +501,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1289,7 +1289,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1379,7 +1379,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1422,7 +1422,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-breaking-change-detect.lock.yml
+++ b/.github/workflows/gh-aw-breaking-change-detect.lock.yml
@@ -114,7 +114,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -584,7 +584,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1378,7 +1378,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1468,7 +1468,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1511,7 +1511,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-breaking-change-detector.lock.yml
+++ b/.github/workflows/gh-aw-breaking-change-detector.lock.yml
@@ -109,7 +109,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -579,7 +579,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1373,7 +1373,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1463,7 +1463,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1506,7 +1506,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-bug-exterminator.lock.yml
+++ b/.github/workflows/gh-aw-bug-exterminator.lock.yml
@@ -108,7 +108,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -486,7 +486,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1274,7 +1274,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1380,7 +1380,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1426,7 +1426,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-bug-hunter.lock.yml
+++ b/.github/workflows/gh-aw-bug-hunter.lock.yml
@@ -109,7 +109,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -574,7 +574,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1368,7 +1368,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1458,7 +1458,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1501,7 +1501,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-code-duplication-detector.lock.yml
+++ b/.github/workflows/gh-aw-code-duplication-detector.lock.yml
@@ -124,7 +124,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -678,7 +678,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1474,7 +1474,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1564,7 +1564,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1607,7 +1607,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-code-duplication-fixer.lock.yml
+++ b/.github/workflows/gh-aw-code-duplication-fixer.lock.yml
@@ -108,7 +108,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -488,7 +488,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1284,7 +1284,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1390,7 +1390,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1436,7 +1436,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-code-quality-audit.lock.yml
+++ b/.github/workflows/gh-aw-code-quality-audit.lock.yml
@@ -113,7 +113,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -592,7 +592,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1390,7 +1390,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1480,7 +1480,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1523,7 +1523,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-code-simplifier.lock.yml
+++ b/.github/workflows/gh-aw-code-simplifier.lock.yml
@@ -108,7 +108,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -502,7 +502,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1290,7 +1290,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1396,7 +1396,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1442,7 +1442,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-create-pr-from-issue.lock.yml
+++ b/.github/workflows/gh-aw-create-pr-from-issue.lock.yml
@@ -120,7 +120,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -478,7 +478,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1332,7 +1332,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1438,7 +1438,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1485,7 +1485,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-deep-research.lock.yml
+++ b/.github/workflows/gh-aw-deep-research.lock.yml
@@ -122,7 +122,7 @@ jobs:
       title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -513,7 +513,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1327,7 +1327,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1416,7 +1416,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1461,7 +1461,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-dependency-review.lock.yml
+++ b/.github/workflows/gh-aw-dependency-review.lock.yml
@@ -110,7 +110,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -612,7 +612,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1417,7 +1417,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1507,7 +1507,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1551,7 +1551,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-docs-drift.lock.yml
+++ b/.github/workflows/gh-aw-docs-drift.lock.yml
@@ -119,7 +119,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -592,7 +592,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1386,7 +1386,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1476,7 +1476,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1519,7 +1519,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-docs-patrol.lock.yml
+++ b/.github/workflows/gh-aw-docs-patrol.lock.yml
@@ -114,7 +114,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -587,7 +587,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1381,7 +1381,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1471,7 +1471,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1514,7 +1514,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml
+++ b/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml
@@ -101,7 +101,7 @@ jobs:
       title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -548,7 +548,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1249,7 +1249,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1339,7 +1339,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1382,7 +1382,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-estc-actions-resource-not-accessible-detector.lock.yml
+++ b/.github/workflows/gh-aw-estc-actions-resource-not-accessible-detector.lock.yml
@@ -116,7 +116,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -538,7 +538,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1333,7 +1333,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1423,7 +1423,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1466,7 +1466,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-estc-docs-patrol-external.lock.yml
+++ b/.github/workflows/gh-aw-estc-docs-patrol-external.lock.yml
@@ -113,7 +113,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -578,7 +578,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1382,7 +1382,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1472,7 +1472,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1515,7 +1515,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-estc-docs-pr-review.lock.yml
+++ b/.github/workflows/gh-aw-estc-docs-pr-review.lock.yml
@@ -120,7 +120,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -610,7 +610,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1462,7 +1462,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1552,7 +1552,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1593,7 +1593,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-estc-downstream-health.lock.yml
+++ b/.github/workflows/gh-aw-estc-downstream-health.lock.yml
@@ -112,7 +112,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -592,7 +592,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1380,7 +1380,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1470,7 +1470,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1513,7 +1513,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-estc-newbie-contributor-patrol-external.lock.yml
+++ b/.github/workflows/gh-aw-estc-newbie-contributor-patrol-external.lock.yml
@@ -107,7 +107,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -526,7 +526,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1323,7 +1323,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1413,7 +1413,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1456,7 +1456,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-estc-pr-buildkite-detective.lock.yml
+++ b/.github/workflows/gh-aw-estc-pr-buildkite-detective.lock.yml
@@ -117,7 +117,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -543,7 +543,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1328,7 +1328,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1418,7 +1418,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1461,7 +1461,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-flaky-test-investigator.lock.yml
+++ b/.github/workflows/gh-aw-flaky-test-investigator.lock.yml
@@ -107,7 +107,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -555,7 +555,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1343,7 +1343,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1433,7 +1433,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1476,7 +1476,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-framework-best-practices.lock.yml
+++ b/.github/workflows/gh-aw-framework-best-practices.lock.yml
@@ -114,7 +114,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -643,7 +643,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1431,7 +1431,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1521,7 +1521,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1564,7 +1564,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-information-architecture.lock.yml
+++ b/.github/workflows/gh-aw-information-architecture.lock.yml
@@ -108,7 +108,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -578,7 +578,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1366,7 +1366,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1456,7 +1456,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1499,7 +1499,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-internal-gemini-cli-web-search.lock.yml
+++ b/.github/workflows/gh-aw-internal-gemini-cli-web-search.lock.yml
@@ -117,7 +117,7 @@ jobs:
       title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -508,7 +508,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1322,7 +1322,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1411,7 +1411,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1456,7 +1456,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-internal-gemini-cli.lock.yml
+++ b/.github/workflows/gh-aw-internal-gemini-cli.lock.yml
@@ -118,7 +118,7 @@ jobs:
       title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -513,7 +513,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1345,7 +1345,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1434,7 +1434,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1479,7 +1479,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-issue-fixer.lock.yml
+++ b/.github/workflows/gh-aw-issue-fixer.lock.yml
@@ -118,7 +118,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -516,7 +516,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1359,7 +1359,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1465,7 +1465,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1513,7 +1513,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-issue-triage.lock.yml
+++ b/.github/workflows/gh-aw-issue-triage.lock.yml
@@ -105,7 +105,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -544,7 +544,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1311,7 +1311,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1401,7 +1401,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1444,7 +1444,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-mention-in-issue-by-id.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-issue-by-id.lock.yml
@@ -126,7 +126,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -496,7 +496,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1432,7 +1432,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1538,7 +1538,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1587,7 +1587,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-mention-in-issue-no-sandbox.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-issue-no-sandbox.lock.yml
@@ -129,7 +129,7 @@ jobs:
       title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -544,7 +544,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1340,7 +1340,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1446,7 +1446,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1496,7 +1496,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-mention-in-issue.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.lock.yml
@@ -129,7 +129,7 @@ jobs:
       title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -548,7 +548,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1484,7 +1484,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1590,7 +1590,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1640,7 +1640,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-mention-in-pr-by-id.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-pr-by-id.lock.yml
@@ -136,7 +136,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -594,7 +594,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1608,7 +1608,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1700,7 +1700,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1746,7 +1746,7 @@ jobs:
       push_commit_url: ${{ steps.process_safe_outputs.outputs.push_commit_url }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-mention-in-pr-no-sandbox.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-pr-no-sandbox.lock.yml
@@ -140,7 +140,7 @@ jobs:
       title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -663,7 +663,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1570,7 +1570,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1662,7 +1662,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1709,7 +1709,7 @@ jobs:
       push_commit_url: ${{ steps.process_safe_outputs.outputs.push_commit_url }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-mention-in-pr.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-pr.lock.yml
@@ -145,7 +145,7 @@ jobs:
       title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -696,7 +696,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1743,7 +1743,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1835,7 +1835,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1882,7 +1882,7 @@ jobs:
       push_commit_url: ${{ steps.process_safe_outputs.outputs.push_commit_url }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-newbie-contributor-fixer.lock.yml
+++ b/.github/workflows/gh-aw-newbie-contributor-fixer.lock.yml
@@ -108,7 +108,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -489,7 +489,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1277,7 +1277,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1383,7 +1383,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1429,7 +1429,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-newbie-contributor-patrol.lock.yml
+++ b/.github/workflows/gh-aw-newbie-contributor-patrol.lock.yml
@@ -107,7 +107,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -517,7 +517,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1305,7 +1305,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1395,7 +1395,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1438,7 +1438,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-performance-profiler.lock.yml
+++ b/.github/workflows/gh-aw-performance-profiler.lock.yml
@@ -109,7 +109,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -625,7 +625,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1419,7 +1419,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1509,7 +1509,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1552,7 +1552,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-plan.lock.yml
+++ b/.github/workflows/gh-aw-plan.lock.yml
@@ -118,7 +118,7 @@ jobs:
       title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -503,7 +503,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1341,7 +1341,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1431,7 +1431,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1476,7 +1476,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-pr-actions-detective.lock.yml
+++ b/.github/workflows/gh-aw-pr-actions-detective.lock.yml
@@ -105,7 +105,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -496,7 +496,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1252,7 +1252,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1342,7 +1342,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1385,7 +1385,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-pr-actions-fixer.lock.yml
+++ b/.github/workflows/gh-aw-pr-actions-fixer.lock.yml
@@ -118,7 +118,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -498,7 +498,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1311,7 +1311,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1403,7 +1403,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1450,7 +1450,7 @@ jobs:
       push_commit_url: ${{ steps.process_safe_outputs.outputs.push_commit_url }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-pr-ci-detective.lock.yml
+++ b/.github/workflows/gh-aw-pr-ci-detective.lock.yml
@@ -110,7 +110,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -501,7 +501,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1257,7 +1257,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1347,7 +1347,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1390,7 +1390,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-pr-labeler.lock.yml
+++ b/.github/workflows/gh-aw-pr-labeler.lock.yml
@@ -85,7 +85,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -401,7 +401,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1202,7 +1202,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1292,7 +1292,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1333,7 +1333,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-pr-review-addresser.lock.yml
+++ b/.github/workflows/gh-aw-pr-review-addresser.lock.yml
@@ -117,7 +117,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -537,7 +537,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1435,7 +1435,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1527,7 +1527,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1574,7 +1574,7 @@ jobs:
       push_commit_url: ${{ steps.process_safe_outputs.outputs.push_commit_url }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-pr-review.lock.yml
+++ b/.github/workflows/gh-aw-pr-review.lock.yml
@@ -119,7 +119,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -548,7 +548,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1392,7 +1392,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1482,7 +1482,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1523,7 +1523,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-product-manager-impersonator.lock.yml
+++ b/.github/workflows/gh-aw-product-manager-impersonator.lock.yml
@@ -118,7 +118,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -626,7 +626,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1414,7 +1414,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1504,7 +1504,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1547,7 +1547,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-project-summary.lock.yml
+++ b/.github/workflows/gh-aw-project-summary.lock.yml
@@ -108,7 +108,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -546,7 +546,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1340,7 +1340,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1430,7 +1430,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1473,7 +1473,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-refactor-opportunist.lock.yml
+++ b/.github/workflows/gh-aw-refactor-opportunist.lock.yml
@@ -109,7 +109,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -600,7 +600,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1394,7 +1394,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1484,7 +1484,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1527,7 +1527,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-release-update.lock.yml
+++ b/.github/workflows/gh-aw-release-update.lock.yml
@@ -107,7 +107,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -456,7 +456,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1244,7 +1244,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1350,7 +1350,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1396,7 +1396,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-scheduled-audit.lock.yml
+++ b/.github/workflows/gh-aw-scheduled-audit.lock.yml
@@ -118,7 +118,7 @@ jobs:
       title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -514,7 +514,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1314,7 +1314,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1404,7 +1404,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1447,7 +1447,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-scheduled-fix.lock.yml
+++ b/.github/workflows/gh-aw-scheduled-fix.lock.yml
@@ -116,7 +116,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -507,7 +507,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1300,7 +1300,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1406,7 +1406,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1452,7 +1452,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-small-problem-fixer.lock.yml
+++ b/.github/workflows/gh-aw-small-problem-fixer.lock.yml
@@ -114,7 +114,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -506,7 +506,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1349,7 +1349,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1455,7 +1455,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1503,7 +1503,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-stale-issues-investigator.lock.yml
+++ b/.github/workflows/gh-aw-stale-issues-investigator.lock.yml
@@ -112,7 +112,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -594,7 +594,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1435,7 +1435,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1525,7 +1525,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1569,7 +1569,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-stale-issues-remediator.lock.yml
+++ b/.github/workflows/gh-aw-stale-issues-remediator.lock.yml
@@ -103,7 +103,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -418,7 +418,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1226,7 +1226,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1316,7 +1316,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1358,7 +1358,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-stale-issues.lock.yml
+++ b/.github/workflows/gh-aw-stale-issues.lock.yml
@@ -117,7 +117,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -599,7 +599,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1440,7 +1440,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1530,7 +1530,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1574,7 +1574,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-test-coverage-detector.lock.yml
+++ b/.github/workflows/gh-aw-test-coverage-detector.lock.yml
@@ -114,7 +114,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -638,7 +638,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1430,7 +1430,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1520,7 +1520,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1563,7 +1563,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-test-improvement.lock.yml
+++ b/.github/workflows/gh-aw-test-improvement.lock.yml
@@ -112,7 +112,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -499,7 +499,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1287,7 +1287,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1393,7 +1393,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1439,7 +1439,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-test-improver.lock.yml
+++ b/.github/workflows/gh-aw-test-improver.lock.yml
@@ -107,7 +107,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -494,7 +494,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1282,7 +1282,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1388,7 +1388,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1434,7 +1434,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-text-auditor.lock.yml
+++ b/.github/workflows/gh-aw-text-auditor.lock.yml
@@ -133,7 +133,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -710,7 +710,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1498,7 +1498,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1588,7 +1588,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1631,7 +1631,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-text-beautifier.lock.yml
+++ b/.github/workflows/gh-aw-text-beautifier.lock.yml
@@ -109,7 +109,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -496,7 +496,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1284,7 +1284,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1390,7 +1390,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1436,7 +1436,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-update-pr-body.lock.yml
+++ b/.github/workflows/gh-aw-update-pr-body.lock.yml
@@ -113,7 +113,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -561,7 +561,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1342,7 +1342,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1432,7 +1432,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1473,7 +1473,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/gh-aw-ux-design-patrol.lock.yml
+++ b/.github/workflows/gh-aw-ux-design-patrol.lock.yml
@@ -114,7 +114,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -596,7 +596,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1390,7 +1390,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1480,7 +1480,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1523,7 +1523,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/internal-downstream-health.lock.yml
+++ b/.github/workflows/internal-downstream-health.lock.yml
@@ -107,7 +107,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -587,7 +587,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1375,7 +1375,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1465,7 +1465,7 @@ jobs:
       matched_command: ''
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1508,7 +1508,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/upgrade-check.lock.yml
+++ b/.github/workflows/upgrade-check.lock.yml
@@ -78,7 +78,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -529,7 +529,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1310,7 +1310,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1417,7 +1417,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/workflow-patrol.lock.yml
+++ b/.github/workflows/workflow-patrol.lock.yml
@@ -78,7 +78,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Generate agentic run info
@@ -519,7 +519,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
@@ -1300,7 +1300,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
@@ -1407,7 +1407,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@902845080df391b1f71845fcd7c303dfc0ac90b3 # v0.57.0
+        uses: strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6 # v0.57.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 # Tool versions
 ACTIONLINT_VERSION := 1.7.10
 ACTION_VALIDATOR_VERSION := 0.8.0
-GH_AW_VERSION := v0.57.0
+GH_AW_VERSION := v0.56.0
 GH_AW_BUILD_VERSION := 4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6
 GH_AW_COMPAT_VERSION := v0.49.4
 GH_AW_MODULE_REPO := github.com/github/gh-aw
 GH_AW_SOURCE_REPO := github.com/strawgate/gh-aw
+GH_AW_SETUP_ACTION_REPO := $(patsubst github.com/%,%,$(GH_AW_SOURCE_REPO))
+GH_AW_SETUP_ACTION_REF := $(GH_AW_BUILD_VERSION)
 
 # Workflows that must be compiled with the compat compiler
 # (no-sandbox workflows hit a threat-detection bug in newer versions)
@@ -43,7 +45,7 @@ define download-file
 	fi
 endef
 
-.PHONY: help setup setup-actionlint setup-action-validator setup-gh setup-gh-macos setup-gh-debian setup-gh-aw compile sync lint-workflows lint-actions test docs-install docs-serve docs-build release
+.PHONY: help setup setup-actionlint setup-action-validator setup-gh setup-gh-macos setup-gh-debian setup-gh-aw compile postprocess-setup-action sync lint-workflows lint-actions test docs-install docs-serve docs-build release
 
 help:
 	@echo "This repository contains GitHub Actions workflows and gh-agent-workflows templates."
@@ -176,7 +178,12 @@ compile: setup-gh-aw setup-gh-aw-compat sync
 	else \
 		echo "No compat workflows to compile"; \
 	fi
+	@$(MAKE) postprocess-setup-action
 	@./scripts/backwards-compat.sh
+
+postprocess-setup-action:
+	@echo "Rewriting setup action references to $(GH_AW_SETUP_ACTION_REPO)@$(GH_AW_SETUP_ACTION_REF)..."
+	@python3 ./scripts/rewrite_setup_action_refs.py "$(GH_AW_SETUP_ACTION_REPO)" "$(GH_AW_SETUP_ACTION_REF)"
 
 setup-actionlint:
 	@echo "Setting up actionlint..."

--- a/scripts/rewrite_setup_action_refs.py
+++ b/scripts/rewrite_setup_action_refs.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Rewrite gh-aw setup action refs in compiled lock files."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: rewrite_setup_action_refs.py <repo> <ref>", file=sys.stderr)
+        return 2
+
+    repo = sys.argv[1].strip()
+    ref = sys.argv[2].strip()
+
+    if not repo or "/" not in repo:
+        print(f"Invalid repo '{repo}'. Expected format owner/repo.", file=sys.stderr)
+        return 2
+    if not ref:
+        print("Ref must not be empty.", file=sys.stderr)
+        return 2
+
+    pattern = re.compile(r"^(\s*uses:\s+)([^@\s]+/actions/setup)@([^\s#]+)(.*)$")
+    updated_files = 0
+    updated_lines = 0
+
+    for path in Path(".").rglob("*.lock.yml"):
+        original = path.read_text(encoding="utf-8")
+        new_lines: list[str] = []
+        file_changed = False
+
+        for line in original.splitlines(keepends=True):
+            match = pattern.match(line.rstrip("\n"))
+            if not match:
+                new_lines.append(line)
+                continue
+
+            prefix, _, _, suffix = match.groups()
+            newline = "\n" if line.endswith("\n") else ""
+            new_line = f"{prefix}{repo}/actions/setup@{ref}{suffix}{newline}"
+            if new_line != line:
+                file_changed = True
+                updated_lines += 1
+            new_lines.append(new_line)
+
+        if file_changed:
+            path.write_text("".join(new_lines), encoding="utf-8")
+            updated_files += 1
+
+    print(f"Updated {updated_lines} setup action reference(s) in {updated_files} lock file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a `postprocess-setup-action` Make target and invoke it from `make compile`
- add `scripts/rewrite_setup_action_refs.py` to rewrite `uses: .../actions/setup@...` in `*.lock.yml`
- default rewrite target to the configured fork compiler source/revision (`strawgate/gh-aw@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6`)

## Test plan
- [x] Run `make postprocess-setup-action`
- [x] Confirm lock files are rewritten to `strawgate/gh-aw/actions/setup@4e5c0a017ef232ec1397e3fa80f59c3ab8f5e6a6`
- [ ] Run full `make compile` in CI

Made with [Cursor](https://cursor.com)