### PR TITLE
ci: support configurable go-version-file

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -15,6 +15,11 @@
       "version": "v5",
       "sha": "40f1582b2485089dde7abd97c1529aa768e1baff"
     },
+    "actions/setup-go@v6": {
+      "repo": "actions/setup-go",
+      "version": "v6",
+      "sha": "4b73464bb391d4059bd26b0524d20df3927bd417"
+    },
     "actions/setup-node@v6": {
       "repo": "actions/setup-node",
       "version": "v6",

--- a/.github/workflows/agent-deep-dive.lock.yml
+++ b/.github/workflows/agent-deep-dive.lock.yml
@@ -35,7 +35,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"07b88cf85bf97107f38c28470228888eeb00f69acfdb3b558ab218f8193a843f"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a05b94fede5fff99bfabb7bb7b51997e5cd1bb78e90e1c0c6864637bb35b4014"}
 
 name: "Internal: Agent Deep Dive"
 "on":
@@ -537,12 +537,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/agent-efficiency.lock.yml
+++ b/.github/workflows/agent-efficiency.lock.yml
@@ -35,7 +35,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"3ba955a0c4b49e913b4f3daa3726a2601e75e4e992a54b2be07d9cde381853c1"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"b2444ee42a3fb583acd68bf86231d6c6850a88ab0b1bc1fcb81ec8fdd29b7985"}
 
 name: "Internal: Agent Efficiency"
 "on":
@@ -503,12 +503,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-agent-suggestions.lock.yml
+++ b/.github/workflows/gh-aw-agent-suggestions.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"7fc941da75fb7e1a6e44c65d17feba0fd75cc2696c2191ec99bdd6821d58c55a"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"9f266eeed980278ddde2b21b38d7776dae6519818abcb38d90d2e9bf926004f0"}
 
 name: "Agent Suggestions"
 "on":
@@ -582,12 +582,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-autonomy-atomicity-analyzer.lock.yml
+++ b/.github/workflows/gh-aw-autonomy-atomicity-analyzer.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e6b891d2c780fd487a6f5004a2886bfd9dc23c395792144ea8bc876a4e8c625f"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ab627f50b514f0e8152e0487b14aa0e9bce1e51420d849d29c08c315f6699460"}
 
 name: "Autonomy Atomicity Analyzer"
 "on":
@@ -586,12 +586,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-branch-actions-detective.lock.yml
+++ b/.github/workflows/gh-aw-branch-actions-detective.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"45fcf517a32e005d0017bbbcfffe592f8b2a6142643c46d6bc57e4d3db55b451"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"567d6b3b1a0ac5527ffe25a6bbf5a5072f3d5e7c133be074a039d58732047223"}
 
 name: "Branch Actions Detective"
 "on":
@@ -510,12 +510,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-breaking-change-detect.lock.yml
+++ b/.github/workflows/gh-aw-breaking-change-detect.lock.yml
@@ -45,7 +45,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1203f1abf841401d657fbdb6db0e821b5ab1798b33ec735417add39401b4f62a"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f7260a21568c32026dc4560d0cbf520d285e6b201ec84041c76e80b9e17b6e0d"}
 
 name: "Breaking Change Detector"
 "on":
@@ -593,12 +593,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-breaking-change-detector.lock.yml
+++ b/.github/workflows/gh-aw-breaking-change-detector.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1203f1abf841401d657fbdb6db0e821b5ab1798b33ec735417add39401b4f62a"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f7260a21568c32026dc4560d0cbf520d285e6b201ec84041c76e80b9e17b6e0d"}
 
 name: "Breaking Change Detector"
 "on":
@@ -588,12 +588,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-bug-exterminator.lock.yml
+++ b/.github/workflows/gh-aw-bug-exterminator.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"3c2652012c326e5743fe90e0469040573dbabad7691ea89c2634d7ac0a5aa0d2"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"704688936890a8f6f56f94997abe629cc81c609e48fa8055ab67c4408d1e1105"}
 
 name: "Gh Aw Bug Exterminator"
 "on":
@@ -495,12 +495,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-bug-hunter.lock.yml
+++ b/.github/workflows/gh-aw-bug-hunter.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f18972f8ae43db9e830fbc058ee742659e0f40cf51e74479b481618358a71d83"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"55b09a2a0c94084bb965fcf1d54b56851bcfe808b11c25ef98df7789862bcedc"}
 
 name: "Bug Hunter"
 "on":
@@ -583,12 +583,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-code-duplication-detector.lock.yml
+++ b/.github/workflows/gh-aw-code-duplication-detector.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"cb73a07e770218a50c178e05e45475919302f7f6ca5b93c99072a9fa6eabcf0d"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"bc268d69607e844aa5854b6e632f921b812b135c61efec9345524898c70ba86e"}
 
 name: "Code Duplication Detector"
 "on":
@@ -687,12 +687,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-code-duplication-fixer.lock.yml
+++ b/.github/workflows/gh-aw-code-duplication-fixer.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"927e82cfa12b5cd853fa87f630bfe20ab12b416dd37887c81d343149ff113db0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f95c7b97f14f792200bcbb53fb5e6411337a5de7c0aba2e11dae218393e88bb7"}
 
 name: "Code Duplication Fixer"
 "on":
@@ -497,12 +497,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-code-quality-audit.lock.yml
+++ b/.github/workflows/gh-aw-code-quality-audit.lock.yml
@@ -41,7 +41,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ab78b7af0ebf1f0bea5c8d3641d971fb09faa6e03c627981f09ca28786093a91"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"b7979bc55fc3f5bc21021074b9d5a883469fc3d7b55531bfec8416d906bb2c75"}
 
 name: "Code Quality Audit"
 "on":
@@ -601,12 +601,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-code-simplifier.lock.yml
+++ b/.github/workflows/gh-aw-code-simplifier.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8f70c19ffa78f95c69390429d1e2eec2d0653c39156b61641d76e790d9b873ef"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"911ef1fabf269b49b9b61df73cd7f28da7b5db7b8128b0bc92753abd47664a84"}
 
 name: "Code Simplifier"
 "on":
@@ -511,12 +511,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-create-pr-from-issue.lock.yml
+++ b/.github/workflows/gh-aw-create-pr-from-issue.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f35e7b7925b0278daf6afe657fedd8b8c130cbd169053322ccb6b4e496fb24b0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"72bdfb1c275fe22522372395b38f75c9ac6ff04a18dbe6c1d5743a862ba8b68f"}
 
 name: "Create PR From Issue"
 "on":
@@ -485,15 +485,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Capture GOROOT for AWF chroot mode
-        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+        name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          cache: true
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-deep-research.lock.yml
+++ b/.github/workflows/gh-aw-deep-research.lock.yml
@@ -41,7 +41,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1c92ebb735e097ba00e609a0f1d21393baf14ab5b41b812133cbfaad0b0f3b01"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f5cee6bdc5d9fe48cff9f512b58ec673cde593d8572b55d00f754e63a762007c"}
 
 name: "Internal Gemini CLI Web Search"
 "on":
@@ -522,12 +522,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-dependency-review.lock.yml
+++ b/.github/workflows/gh-aw-dependency-review.lock.yml
@@ -36,7 +36,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1220b4a345844709c33fe207dc47c680e8e00d0c7f0a4806e52631f4de0cb241"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1e0178f538f0c847870a8d6d701d9db60f289c4a68cfcecb2b31637db0b9af4f"}
 
 name: "Dependency Review"
 "on":
@@ -621,12 +621,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-docs-drift.lock.yml
+++ b/.github/workflows/gh-aw-docs-drift.lock.yml
@@ -45,7 +45,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a5d6b79de53e3c2364d494ad842dae8f1a23416f1680040cec904e70d7d4071c"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"47f6053661459d1435abdde9ea0bde1f216a83fd8278015fb4c0fdc1240787e3"}
 
 name: "Docs Patrol"
 "on":
@@ -601,12 +601,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-docs-patrol.lock.yml
+++ b/.github/workflows/gh-aw-docs-patrol.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a5d6b79de53e3c2364d494ad842dae8f1a23416f1680040cec904e70d7d4071c"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"47f6053661459d1435abdde9ea0bde1f216a83fd8278015fb4c0fdc1240787e3"}
 
 name: "Docs Patrol"
 "on":
@@ -596,12 +596,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-estc-actions-resource-not-accessible-detector.lock.yml
+++ b/.github/workflows/gh-aw-estc-actions-resource-not-accessible-detector.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"dba21fdbf97f4744dc0225c6502707833bed3b75e1632b720a6aba4099105ebf"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a9ab349673fb8193b65f876023afdc4a5c57d0c7e9a755b659559cd14358f201"}
 
 name: "Resource Not Accessible By Integration Detector"
 "on":
@@ -547,12 +547,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-estc-docs-patrol-external.lock.yml
+++ b/.github/workflows/gh-aw-estc-docs-patrol-external.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"9eb77ccbeebb722a5a4d118ff0b0c4fa39c8bc5cf165bf80a25e2939a1a7c18c"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6defe699a4fd3734ccf771eda0638d567a656ef4c3badf1193b9018e8c7adede"}
 
 name: "Estc Docs Patrol External"
 "on":
@@ -587,12 +587,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-estc-docs-pr-review.lock.yml
+++ b/.github/workflows/gh-aw-estc-docs-pr-review.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"441969b48493ad34a003e5a6780aeff60b640a07a1c13d4c4e73545ad902a67c"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"d8c04beec590827783656d2c6425614a3d40b0a45dcc4a8f3bda45689b52e02e"}
 
 name: "Estc Docs PR Review"
 "on":
@@ -619,12 +619,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-estc-downstream-health.lock.yml
+++ b/.github/workflows/gh-aw-estc-downstream-health.lock.yml
@@ -43,7 +43,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4802f48023cb8082365a29b9f0668c4552893dbd16947ab2ec8c3738ccc97d6b"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"03fe71ea119e870c1ca3022f3463154ff252e6dfec288bae1fbcc9bf9ecad8cf"}
 
 name: "Internal: Downstream Health"
 "on":
@@ -601,12 +601,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-estc-newbie-contributor-patrol-external.lock.yml
+++ b/.github/workflows/gh-aw-estc-newbie-contributor-patrol-external.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f039b07993c82ed62e951da93d4d7cdd97b6a38fb74ad48f9556b8b224a31ec7"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e32d71ad1a442d9bdd7273400466d999541601021ec41252eac8b33658c3d9b1"}
 
 name: "Estc Newbie Contributor Patrol External"
 "on":
@@ -535,12 +535,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-estc-pr-buildkite-detective.lock.yml
+++ b/.github/workflows/gh-aw-estc-pr-buildkite-detective.lock.yml
@@ -36,7 +36,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"3882c6673727a6d21ba110797bf529eb51a5dd30d5804598ae6495a118485d5f"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"7ea47930f22bf7b84323ccc205ec1d23b5b85eda871ed1463d90683e855ad0a3"}
 
 name: "PR Buildkite Detective"
 "on":
@@ -537,12 +537,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-flaky-test-investigator.lock.yml
+++ b/.github/workflows/gh-aw-flaky-test-investigator.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"c399aa3796716736cf5336b1c8f7f732c18421a159be8016aa3fe7fc631b47d6"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"9e84dc8fc73238637aeb6fb9188c7183d40c10765a22204335fa5489a1eacd22"}
 
 name: "Flaky Test Investigator"
 "on":
@@ -564,12 +564,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-fragments/runtime-setup.md
+++ b/.github/workflows/gh-aw-fragments/runtime-setup.md
@@ -1,10 +1,10 @@
 ---
 steps:
   - name: Setup Go
-    if: hashFiles('go.mod') != ''
-    uses: actions/setup-go@v5
+    if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+    uses: actions/setup-go@v6
     with:
-      go-version-file: go.mod
+      go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       cache: true
 
   - name: Setup Python

--- a/.github/workflows/gh-aw-framework-best-practices.lock.yml
+++ b/.github/workflows/gh-aw-framework-best-practices.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"48d6200533272a7c922a6e852261841ab1b6b2b62a2675346a0b1a16ea9d4c5c"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"44001bd309113d0d513fa8c2b3553f364a2179192b1cf76e5845bf9712201b64"}
 
 name: "Framework Best Practices"
 "on":
@@ -652,12 +652,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-information-architecture.lock.yml
+++ b/.github/workflows/gh-aw-information-architecture.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"aaa5c2a12f44cb6d6fb6cdeb829817060c198fad097fa941ae9b5da49c59b7c5"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"222c5112cef56655be96ab36b14ced9fbe8986d02f4136a1950d6161af7a75bf"}
 
 name: "Information Architecture"
 "on":
@@ -587,12 +587,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-internal-gemini-cli-web-search.lock.yml
+++ b/.github/workflows/gh-aw-internal-gemini-cli-web-search.lock.yml
@@ -36,7 +36,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1c92ebb735e097ba00e609a0f1d21393baf14ab5b41b812133cbfaad0b0f3b01"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f5cee6bdc5d9fe48cff9f512b58ec673cde593d8572b55d00f754e63a762007c"}
 
 name: "Internal Gemini CLI Web Search"
 "on":
@@ -517,12 +517,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-internal-gemini-cli.lock.yml
+++ b/.github/workflows/gh-aw-internal-gemini-cli.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"2923c718d5fbdff7b949a90010e221e810e5fa23edca2bf620cb77b551bab573"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"80d0dc94eb2ea3ca320f59f48755135775f498f1087541d83a2403fd52ff6968"}
 
 name: "Internal Gemini CLI"
 "on":
@@ -520,15 +520,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Capture GOROOT for AWF chroot mode
-        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+        name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          cache: true
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-issue-fixer.lock.yml
+++ b/.github/workflows/gh-aw-issue-fixer.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4189805b6e720a7588d8b1390bb1e25a4c47f36d3c26af660526299110254918"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"9eba3d7730076140a19ad110c255e5f1cccf6cd150d6ae5881edc6ab62229758"}
 
 name: "Issue Fixer"
 "on":
@@ -525,12 +525,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-issue-triage.lock.yml
+++ b/.github/workflows/gh-aw-issue-triage.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"c582b3a98015e6b2888186cbbece6c110a8f0f64eff64eb410c26fc2a7e3e535"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4f0006ac4606ac4e36570d65292a087fba26a4e58f43d6c03620a8988ab9f207"}
 
 name: "Issue Triage"
 "on":
@@ -551,15 +551,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Capture GOROOT for AWF chroot mode
-        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+        name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          cache: true
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-mention-in-issue-by-id.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-issue-by-id.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"aeda2b4acb2bc4726bc5cd12c3ce45e62a32a7bc62ab6477eeda5e077a6a76bb"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"abbe84d135e0f14e540d2ea0cbfa00030f2bcc99a3b2615b8a1a3a52f73dc397"}
 
 name: "Mention in Issue by ID"
 "on":
@@ -503,15 +503,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Capture GOROOT for AWF chroot mode
-        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+        name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          cache: true
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-mention-in-issue-no-sandbox.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-issue-no-sandbox.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"b20e014fe9ddfa088ff69894e70eccceb97fa2c714ef08404938a4a542de238b"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"74958e88b3d60f17a931e0cb8ebed409edd9a6d5f51e2fb7c9b78eb2fa7ccfe9"}
 
 name: "Mention in Issue (no sandbox)"
 "on":
@@ -551,15 +551,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Capture GOROOT for AWF chroot mode
-        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+        name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          cache: true
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-mention-in-issue.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"56a8d9f3d3168716e6699f972a8e076f28a498515c69ec389ce5e28f4cdc0b44"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a73afb31f1a0c5b61a89fd43e9cc606a1d63087433746456dec99ded6bf8c3a6"}
 
 name: "Mention in Issue"
 "on":
@@ -555,15 +555,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Capture GOROOT for AWF chroot mode
-        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+        name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          cache: true
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-mention-in-pr-by-id.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-pr-by-id.lock.yml
@@ -46,7 +46,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a499fc33135e2e752e7bb293aede8deb27187c5aae052237d75ef80f219c0e8e"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"444be1fa1a30f3e71eb316fe19b2cf4bc30203b5185651a963df9ead77436433"}
 
 name: "Mention in PR by ID"
 "on":
@@ -601,15 +601,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Capture GOROOT for AWF chroot mode
-        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+        name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          cache: true
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-mention-in-pr-no-sandbox.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-pr-no-sandbox.lock.yml
@@ -47,7 +47,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"37dccf03a04614e647b5a7e91c58da5936232825e9cca581e4a0572bd618c964"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"684e70c6b5bd76c4857a2021ca0df3465d0a313c0d7fda1de3b944d86d7b8660"}
 
 name: "Mention in PR (no sandbox)"
 "on":
@@ -670,15 +670,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Capture GOROOT for AWF chroot mode
-        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+        name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          cache: true
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-mention-in-pr.lock.yml
+++ b/.github/workflows/gh-aw-mention-in-pr.lock.yml
@@ -47,7 +47,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4e7704afed78a6f7933911f10d4f15d434e1628981d8b63f041c3c4cacfc66a6"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"10f15082ce17a36d1868c09144b66fd0efdd38b8537bb44b54e4a5f164fd8e5d"}
 
 name: "Mention in PR"
 "on":
@@ -703,15 +703,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Capture GOROOT for AWF chroot mode
-        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+        name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          cache: true
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-newbie-contributor-fixer.lock.yml
+++ b/.github/workflows/gh-aw-newbie-contributor-fixer.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"43b0b618c93aa6eb3e3297529b3ec862e9742e6a4426fc44909f9ed2c3130649"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"7e7f1d1935d929e4f5cfecc44a1db44f2f580fb3da0a9247b04fb6668f5b1f92"}
 
 name: "Newbie Contributor Fixer"
 "on":
@@ -498,12 +498,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-newbie-contributor-patrol.lock.yml
+++ b/.github/workflows/gh-aw-newbie-contributor-patrol.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"db5cfd94a9313aa9efa5f4bd75aec08f3249e38cb6594d61f8980687057c2b21"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"099b3df1a88a95ad403d263090323525f5f6844c3ab8ea3b362870a3e52d2fe4"}
 
 name: "Newbie Contributor Patrol"
 "on":
@@ -526,12 +526,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-performance-profiler.lock.yml
+++ b/.github/workflows/gh-aw-performance-profiler.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"acce9f63ac26d9b0ea7fff62bacac6866350059c2b95f72af4e520b7c1dd2ee1"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"b2953f9a6c8dc9faa146359f9bdb47052105951336f271ecdb842f237dca3ccf"}
 
 name: "Performance Profiler"
 "on":
@@ -54,6 +54,11 @@ name: "Performance Profiler"
       allowed-bot-users:
         default: github-actions[bot]
         description: Allowlisted bot actor usernames (comma-separated)
+        required: false
+        type: string
+      go-version-file:
+        default: go.mod
+        description: Path to the Go version file
         required: false
         type: string
       messages-footer:
@@ -634,12 +639,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-performance-profiler.md
+++ b/.github/workflows/gh-aw-performance-profiler.md
@@ -51,6 +51,11 @@ on:
         type: string
         required: false
         default: "[performance-profiler]"
+      go-version-file:
+        description: "Path to the Go version file"
+        type: string
+        required: false
+        default: "go.mod"
     secrets:
       COPILOT_GITHUB_TOKEN:
         required: true

--- a/.github/workflows/gh-aw-plan.lock.yml
+++ b/.github/workflows/gh-aw-plan.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"355b78a79dbf1cd7be81b51e72fa7d71825837dbd4f3c7d48f7496df3fd5d9d0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a222ada8d90455163c36fbe436867ed5250c3bab3d94b3f4ae19b31214e85a55"}
 
 name: "Plan"
 "on":
@@ -512,12 +512,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-pr-actions-detective.lock.yml
+++ b/.github/workflows/gh-aw-pr-actions-detective.lock.yml
@@ -36,7 +36,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"09ffeba1c092c9997c042f3dc2e44afb0415897dbf75408b8e3d32f92eac6ae1"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6c3905854bb48cb4217337c750656c7b6009cc581104a7ca6dd5a8c603ac80b4"}
 
 name: "PR Actions Detective"
 "on":
@@ -505,12 +505,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-pr-actions-fixer.lock.yml
+++ b/.github/workflows/gh-aw-pr-actions-fixer.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f7433722bcb83e7647f81fbb49b3daad8a3bf9ec49e9cedbcddbe0a0cd9fea84"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a44c57a44a6d2a8d087b53e7c00f43eb8f940e9429444db640009a70e8ae1619"}
 
 name: "PR Actions Fixer"
 "on":
@@ -511,12 +511,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-pr-ci-detective.lock.yml
+++ b/.github/workflows/gh-aw-pr-ci-detective.lock.yml
@@ -41,7 +41,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"09ffeba1c092c9997c042f3dc2e44afb0415897dbf75408b8e3d32f92eac6ae1"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6c3905854bb48cb4217337c750656c7b6009cc581104a7ca6dd5a8c603ac80b4"}
 
 name: "PR Actions Detective"
 "on":
@@ -510,12 +510,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-pr-labeler.lock.yml
+++ b/.github/workflows/gh-aw-pr-labeler.lock.yml
@@ -34,7 +34,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1fc9c7643998f11988c821415ea389509f1c341bbbfb4f2e37d53b230545d47c"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f57325010446dbec1e6556656b45cee90be7fa4d6c0c417f4e18baa5c0b48457"}
 
 name: "PR Labeler"
 "on":
@@ -410,12 +410,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-pr-review-addresser.lock.yml
+++ b/.github/workflows/gh-aw-pr-review-addresser.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"3a21173488b4be8d36e6bbf21665903ff788343d753f6d6435325c49a19a9ad0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"41555d5cefa865957d3ec00f81175b2614aaf3f1f2bc7484996fa5987e0bca36"}
 
 name: "PR Review Addresser"
 "on":
@@ -546,12 +546,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-pr-review.lock.yml
+++ b/.github/workflows/gh-aw-pr-review.lock.yml
@@ -41,7 +41,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8ae920f0ce63ae3e42f3b6ba8a9da6a53916bdc6a7e1451671cd0de20fed4edb"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e479083179f9ffeb498c2405cde7511c7b53b4219a37db1d2c6eb6299876af65"}
 
 name: "PR Review"
 "on":
@@ -557,12 +557,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-product-manager-impersonator.lock.yml
+++ b/.github/workflows/gh-aw-product-manager-impersonator.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"54ed9c5d6c2eb28933059ed81268a9a6ab3e87b9f0de08c85df2775afd4bdcbc"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ef209e2b14e7ae45186a2a49f2049bf49215cb7e1e41fc600149f8ea95897264"}
 
 name: "Product Manager Impersonator"
 "on":
@@ -635,12 +635,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-project-summary.lock.yml
+++ b/.github/workflows/gh-aw-project-summary.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4d652d63aab9bcf3ffa518810cbc4722be6a8a364c7b1272ae292ffef9b9fcfd"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ba868e7fdc61a0b2be907bbf9591410a98ede72f66d920ad7b0ca6e4eaf44648"}
 
 name: "Project Summary"
 "on":
@@ -555,12 +555,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-refactor-opportunist.lock.yml
+++ b/.github/workflows/gh-aw-refactor-opportunist.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6214eff06e8650577ee3a09a0e5f106c641063e8fc7c835fabca59b03b447116"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1184528dc17bdd59b33c151babed89f2c1e8b8b52fef1aec7209bf5efccfd7bd"}
 
 name: "Refactor Opportunist"
 "on":
@@ -609,12 +609,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-release-update.lock.yml
+++ b/.github/workflows/gh-aw-release-update.lock.yml
@@ -36,7 +36,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"18824bd8f31a3bc7694efe19a0d03cbfce72a34edf32e629d5047b3b52b3a324"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"3be175f13c28e51a37d2f33c2eb022415abd39d87ee16eb1511567105577a8cb"}
 
 name: "Release Update Check"
 "on":
@@ -465,12 +465,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-scheduled-audit.lock.yml
+++ b/.github/workflows/gh-aw-scheduled-audit.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"c373e7b1df94ce516d66d4734713a7a81179d9bcc48a757ea95810981a08b19f"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"d4d5297be5c431796b3added840e38cba1ba0466473a87f3420c8f4e6acafd82"}
 
 name: "Scheduled Audit"
 "on":
@@ -521,15 +521,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Capture GOROOT for AWF chroot mode
-        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
+        name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          cache: true
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-scheduled-fix.lock.yml
+++ b/.github/workflows/gh-aw-scheduled-fix.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"dfbed8d70e2f4ef2729cb82d8eb9cb2de53104e9019bb77f5f2b356093cc7d03"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ab54275bbd8c04ee014fcaea0ac6e464d291a033e39eb6bacc08650b3adbbfd3"}
 
 name: "Scheduled Fix"
 "on":
@@ -516,12 +516,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-small-problem-fixer.lock.yml
+++ b/.github/workflows/gh-aw-small-problem-fixer.lock.yml
@@ -37,7 +37,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8a4aea8396318c8a72bd33a8abb39cf77ae2b8fd27ae405e34994e692eeb2719"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ea8c383b3fe645d1b6627005124094ead1a1d85f05d4ea4a16e20d413621fdc1"}
 
 name: "Small Problem Fixer"
 "on":
@@ -515,12 +515,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-stale-issues-investigator.lock.yml
+++ b/.github/workflows/gh-aw-stale-issues-investigator.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"fd9cea41a8019f2623a696c8d4fd2f1f017e7c1afe2a891ad9866f18919c5426"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"34260b1fbce092a8c404e4fca4fc8009c6e6d3caa62bafedcbf53d1043d3120b"}
 
 name: "Stale Issues Investigator"
 "on":
@@ -603,12 +603,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-stale-issues-remediator.lock.yml
+++ b/.github/workflows/gh-aw-stale-issues-remediator.lock.yml
@@ -35,7 +35,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"0d089b2b550519f8ddd2dcaf715ffb981bf90c334dbe8e4521b72edda8e2f6fc"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"7b34823ad32625a301e735980f288d1f17fbff021927e44a0d3919b9eac94494"}
 
 name: "Stale Issues Remediator"
 "on":
@@ -427,12 +427,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-stale-issues.lock.yml
+++ b/.github/workflows/gh-aw-stale-issues.lock.yml
@@ -43,7 +43,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"fd9cea41a8019f2623a696c8d4fd2f1f017e7c1afe2a891ad9866f18919c5426"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"34260b1fbce092a8c404e4fca4fc8009c6e6d3caa62bafedcbf53d1043d3120b"}
 
 name: "Stale Issues Investigator"
 "on":
@@ -608,12 +608,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-test-coverage-detector.lock.yml
+++ b/.github/workflows/gh-aw-test-coverage-detector.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"82bb41f9d760cce45ac80448e67e12bd11ee109a9c7639252ddf77af2b950bb5"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8a4c590b6f699cb03f0659a37568050dfcdaa8b2276fa8dbb353f41e8960dd93"}
 
 name: "Test Coverage Detector"
 "on":
@@ -647,12 +647,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-test-improvement.lock.yml
+++ b/.github/workflows/gh-aw-test-improvement.lock.yml
@@ -41,7 +41,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"89e4239a4d7878cce0970190c0353210987167bfcef993b08ab23a40a59a2b58"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"174070de34cc0ad36ef820dcae14458266013774cd574dc01b18bdb3cea5dad6"}
 
 name: "Test Improver"
 "on":
@@ -508,12 +508,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-test-improver.lock.yml
+++ b/.github/workflows/gh-aw-test-improver.lock.yml
@@ -36,7 +36,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"89e4239a4d7878cce0970190c0353210987167bfcef993b08ab23a40a59a2b58"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"174070de34cc0ad36ef820dcae14458266013774cd574dc01b18bdb3cea5dad6"}
 
 name: "Test Improver"
 "on":
@@ -503,12 +503,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-text-auditor.lock.yml
+++ b/.github/workflows/gh-aw-text-auditor.lock.yml
@@ -39,7 +39,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"9f85b859cccca85df3e8e44a14d1d264f07b81959836216418dd592f980a1e65"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8a3bf3ffbb19d556782f1477531dec1d6aaaf03f6a8669daa41a44f2a9493577"}
 
 name: "Text Auditor"
 "on":
@@ -719,12 +719,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-text-beautifier.lock.yml
+++ b/.github/workflows/gh-aw-text-beautifier.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"678de2fb587d8e6af060b75c78edf9db5dfd5e99bdbbccce465fd95c598ea0ad"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"2a3e077868687841b4ede464913c879386e596b4d1628a4aaebf02abe301c411"}
 
 name: "Text Beautifier"
 "on":
@@ -505,12 +505,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-update-pr-body.lock.yml
+++ b/.github/workflows/gh-aw-update-pr-body.lock.yml
@@ -35,7 +35,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"06bcba835bef692fc673bf7815b460a6f70f125eb68199113f59d021133c72f6"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a6651c4a00b64a0d9c037f12c1cda9cd8bf0998743e182ada12206284ae23628"}
 
 name: "Update PR Body"
 "on":
@@ -570,12 +570,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/gh-aw-ux-design-patrol.lock.yml
+++ b/.github/workflows/gh-aw-ux-design-patrol.lock.yml
@@ -40,7 +40,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a8c64505282ae9e783a50100133e590d8f1b7be390784ec494ac6cdb9c173a52"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1a5272287a23840bef43c844291153c8e849a5bda0edf349b3a2657b12aa2c5c"}
 
 name: "UX Design Patrol"
 "on":
@@ -605,12 +605,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/internal-downstream-health.lock.yml
+++ b/.github/workflows/internal-downstream-health.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4802f48023cb8082365a29b9f0668c4552893dbd16947ab2ec8c3738ccc97d6b"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"03fe71ea119e870c1ca3022f3463154ff252e6dfec288bae1fbcc9bf9ecad8cf"}
 
 name: "Internal: Downstream Health"
 "on":
@@ -596,12 +596,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/upgrade-check.lock.yml
+++ b/.github/workflows/upgrade-check.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"c61f29b17d22e90d25fa9dd2fd61ead5cc5cfff58a171802757c4e4eca63a19b"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e43003e592add6d540163bc0b4e70f9aa77d753dca6b5b028f3ea9e3c9d24669"}
 
 name: "Internal: Upgrade Check"
 "on":
@@ -538,12 +538,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/workflow-patrol.lock.yml
+++ b/.github/workflows/workflow-patrol.lock.yml
@@ -38,7 +38,7 @@
 #
 # inlined-imports: true
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e49e29d4ccef1a330ef1e458c9a3cdd165ee3e87c1f5a5611f56c318f658b934"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8e347ed691a5aac4efdee9b0bda8bb3ca3339f53e39f865ee0628493cae331fe"}
 
 name: "Internal: Workflow Patrol"
 "on":
@@ -528,12 +528,12 @@ jobs:
           persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      - if: hashFiles('go.mod') != ''
+      - if: hashFiles(inputs['go-version-file'] || 'go.mod') != ''
         name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           cache: true
-          go-version-file: go.mod
+          go-version-file: ${{ inputs['go-version-file'] || 'go.mod' }}
       - if: hashFiles('.python-version') != ''
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
Add `go-version-file` input to performance profiler workflow. Use this input in runtime setup for the Setup Go step. Fall back to `go.mod` when no input is provided. This allows repositories with `go.mod` that aren't in the root directory to specify a custom version file path.

## Summary

<!-- Describe what changes were made and why -->

## Validation

<!-- List the commands run to verify the changes -->

```bash
make compile          # sync triggers + compile to lock files
make lint             # run all linters
```

## Pre-Completion Checklist

- [ ] Re-read the issue or request and confirmed this PR directly addresses it
- [ ] Reviewed all changed files for correctness
- [ ] Ran `make compile` and `make lint` with no errors
- [ ] Verified no unrelated files were modified
