### PR TITLE
fix: correct broken detector-fixer-chaining links causing Docs build failure

### DIFF
--- a/gh-agent-workflows/code-complexity-detector/README.md
+++ b/gh-agent-workflows/code-complexity-detector/README.md
@@ -41,4 +41,4 @@ See [example.yml](example.yml) for the full workflow file.
 
 ## Pairing
 
-This detector finds complexity hotspots. Chain it to [Create PR from Issue](../../docs/workflows/detector-fixer-chaining.md) to automatically fix findings.
+This detector finds complexity hotspots. Chain it to [Create PR from Issue](../detector-fixer-chaining.md) to automatically fix findings.

--- a/gh-agent-workflows/newbie-contributor-patrol/README.md
+++ b/gh-agent-workflows/newbie-contributor-patrol/README.md
@@ -37,4 +37,4 @@ See [example.yml](example.yml) for the full workflow file.
 
 ## Pairing
 
-This detector finds onboarding documentation gaps. Chain it to [Create PR from Issue](../../docs/workflows/detector-fixer-chaining.md) to automatically fix findings.
+This detector finds onboarding documentation gaps. Chain it to [Create PR from Issue](../detector-fixer-chaining.md) to automatically fix findings.

--- a/gh-agent-workflows/scheduled-fix/README.md
+++ b/gh-agent-workflows/scheduled-fix/README.md
@@ -6,7 +6,7 @@ Generic base workflow for scheduled fixers — pick up an open issue and create 
 
 The fix agent follows a standard 5-step process (gather candidates, select target, implement, quality gate, create PR) defined by the `scheduled-fix` fragment. You provide the **Fix Assignment** via the `additional-instructions` input, which tells the agent how to find issues, what kind of changes to make, and any domain-specific constraints.
 
-This is the base workflow for building custom fixers. For most use cases, chain a detector directly to Create PR from Issue instead of writing a dedicated fixer. See [Detector / Fixer Chaining](../../docs/workflows/detector-fixer-chaining.md) for the pattern.
+This is the base workflow for building custom fixers. For most use cases, chain a detector directly to Create PR from Issue instead of writing a dedicated fixer. See [Detector / Fixer Chaining](../detector-fixer-chaining.md) for the pattern.
 
 ## Quick Install
 

--- a/gh-agent-workflows/test-coverage-detector/README.md
+++ b/gh-agent-workflows/test-coverage-detector/README.md
@@ -37,4 +37,4 @@ See [example.yml](example.yml) for the full workflow file.
 
 ## Pairing
 
-This detector finds test coverage gaps. Chain it to [Create PR from Issue](../../docs/workflows/detector-fixer-chaining.md) to automatically fix findings.
+This detector finds test coverage gaps. Chain it to [Create PR from Issue](../detector-fixer-chaining.md) to automatically fix findings.


### PR DESCRIPTION
## Summary

- Fixes 4 broken links that were causing the `Internal: Docs / build` CI to fail in strict mode
- The `hooks.py` link-rewriting regex (`\.\./([a-z0-9-]+)/`) was matching `../docs/` inside `../../docs/workflows/detector-fixer-chaining.md`, replacing it with `docs.md` and producing the invalid path `../docs.mdworkflows/detector-fixer-chaining.md`
- Changed the links in 4 README files to use `../detector-fixer-chaining.md` directly — the correct relative path for the generated docs pages, and a form not affected by the hook's sibling-rewrite regex

## Files changed

- `gh-agent-workflows/code-complexity-detector/README.md`
- `gh-agent-workflows/newbie-contributor-patrol/README.md`
- `gh-agent-workflows/scheduled-fix/README.md`
- `gh-agent-workflows/test-coverage-detector/README.md`

## Test plan

- [ ] `Internal: Docs / build` CI passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)