### PR TITLE
fix(workflows): align trigger permissions with GH-AW lock files

### DIFF
--- a/.github/workflows/trigger-agent-suggestions.yml
+++ b/.github/workflows/trigger-agent-suggestions.yml
@@ -7,7 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/.github/workflows/trigger-autonomy-atomicity-analyzer.yml
+++ b/.github/workflows/trigger-autonomy-atomicity-analyzer.yml
@@ -7,7 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/.github/workflows/trigger-branch-actions-detective.yml
+++ b/.github/workflows/trigger-branch-actions-detective.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
 
 jobs:

--- a/.github/workflows/trigger-breaking-change-detector.yml
+++ b/.github/workflows/trigger-breaking-change-detector.yml
@@ -7,7 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/.github/workflows/trigger-bug-hunter.yml
+++ b/.github/workflows/trigger-bug-hunter.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   actions: read
   contents: write
+  copilot-requests: write
   issues: write
   pull-requests: write
 

--- a/.github/workflows/trigger-code-complexity-detector.yml
+++ b/.github/workflows/trigger-code-complexity-detector.yml
@@ -7,11 +7,12 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
+  copilot-requests: write
   issues: write
   pull-requests: write
 
-  actions: read
 jobs:
   run:
     uses: ./.github/workflows/gh-aw-code-complexity-detector.lock.yml

--- a/.github/workflows/trigger-code-duplication-detector.yml
+++ b/.github/workflows/trigger-code-duplication-detector.yml
@@ -7,11 +7,12 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
+  copilot-requests: write
   issues: write
   pull-requests: write
 
-  actions: read
 jobs:
   run:
     uses: ./.github/workflows/gh-aw-code-duplication-detector.lock.yml

--- a/.github/workflows/trigger-dependency-review.yml
+++ b/.github/workflows/trigger-dependency-review.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: write
 

--- a/.github/workflows/trigger-docs-patrol.yml
+++ b/.github/workflows/trigger-docs-patrol.yml
@@ -7,11 +7,12 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
+  copilot-requests: write
   issues: write
   pull-requests: write
 
-  actions: read
 jobs:
   run:
     uses: ./.github/workflows/gh-aw-docs-patrol.lock.yml

--- a/.github/workflows/trigger-duplicate-issue-detector.yml
+++ b/.github/workflows/trigger-duplicate-issue-detector.yml
@@ -6,8 +6,9 @@ on:
     types: [opened]
 
 permissions:
+  actions: read
   contents: read
-  discussions: write
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/.github/workflows/trigger-estc-docs-pr-review.yml
+++ b/.github/workflows/trigger-estc-docs-pr-review.yml
@@ -6,11 +6,12 @@ on:
     types: [created]
 
 permissions:
+  actions: read
+  checks: read
   contents: read
+  copilot-requests: write
   issues: read
   pull-requests: write
-  checks: read
-  actions: read
 
 jobs:
   run:

--- a/.github/workflows/trigger-estc-pr-buildkite-detective.yml
+++ b/.github/workflows/trigger-estc-pr-buildkite-detective.yml
@@ -9,8 +9,8 @@ on:
 permissions:
   actions: read
   contents: read
-  discussions: write
-  issues: write
+  copilot-requests: write
+  issues: read
   pull-requests: write  # required by gh-aw compiler for add-comment (github/gh-aw#16673)
 
 jobs:

--- a/.github/workflows/trigger-framework-best-practices.yml
+++ b/.github/workflows/trigger-framework-best-practices.yml
@@ -7,11 +7,12 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
+  copilot-requests: write
   issues: write
   pull-requests: write
 
-  actions: read
 jobs:
   run:
     uses: ./.github/workflows/gh-aw-framework-best-practices.lock.yml

--- a/.github/workflows/trigger-information-architecture.yml
+++ b/.github/workflows/trigger-information-architecture.yml
@@ -7,7 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/.github/workflows/trigger-internal-downstream-health.yml
+++ b/.github/workflows/trigger-internal-downstream-health.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/.github/workflows/trigger-internal-gemini-cli-web-search.yml
+++ b/.github/workflows/trigger-internal-gemini-cli-web-search.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-internal-gemini-cli.yml
+++ b/.github/workflows/trigger-internal-gemini-cli.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-issue-triage.yml
+++ b/.github/workflows/trigger-issue-triage.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-mention-in-issue.yml
+++ b/.github/workflows/trigger-mention-in-issue.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: read
   contents: write
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-mention-in-pr.yml
+++ b/.github/workflows/trigger-mention-in-pr.yml
@@ -10,8 +10,8 @@ on:
 permissions:
   actions: read
   contents: write
-  discussions: write
-  issues: write
+  copilot-requests: write
+  issues: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/trigger-newbie-contributor-patrol.yml
+++ b/.github/workflows/trigger-newbie-contributor-patrol.yml
@@ -7,11 +7,12 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
+  copilot-requests: write
   issues: write
   pull-requests: write
 
-  actions: read
 jobs:
   run:
     uses: ./.github/workflows/gh-aw-newbie-contributor-patrol.lock.yml

--- a/.github/workflows/trigger-plan.yml
+++ b/.github/workflows/trigger-plan.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-pr-actions-detective.yml
+++ b/.github/workflows/trigger-pr-actions-detective.yml
@@ -9,8 +9,9 @@ on:
 permissions:
   actions: read
   contents: read
-  issues: write
-  pull-requests: read
+  copilot-requests: write
+  issues: read
+  pull-requests: write
 
 jobs:
   run:

--- a/.github/workflows/trigger-pr-conflict-addresser.yml
+++ b/.github/workflows/trigger-pr-conflict-addresser.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   actions: read
   contents: write
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-pr-labeler.yml
+++ b/.github/workflows/trigger-pr-labeler.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: write
 

--- a/.github/workflows/trigger-pr-review.yml
+++ b/.github/workflows/trigger-pr-review.yml
@@ -8,7 +8,8 @@ on:
 permissions:
   actions: read
   contents: read
-  issues: write  # needed for no-op run tracking issue
+  copilot-requests: write
+  issues: read  # needed for no-op run tracking issue
   pull-requests: write
 
 jobs:

--- a/.github/workflows/trigger-product-manager-impersonator.yml
+++ b/.github/workflows/trigger-product-manager-impersonator.yml
@@ -7,7 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/.github/workflows/trigger-project-summary.yml
+++ b/.github/workflows/trigger-project-summary.yml
@@ -7,7 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/.github/workflows/trigger-prompt-audit.yml
+++ b/.github/workflows/trigger-prompt-audit.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/.github/workflows/trigger-refactor-opportunist.yml
+++ b/.github/workflows/trigger-refactor-opportunist.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/.github/workflows/trigger-stale-issues-investigator.yml
+++ b/.github/workflows/trigger-stale-issues-investigator.yml
@@ -7,9 +7,11 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:

--- a/.github/workflows/trigger-stale-issues-remediator.yml
+++ b/.github/workflows/trigger-stale-issues-remediator.yml
@@ -7,8 +7,11 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
+  pull-requests: write
 
 jobs:
   run:

--- a/.github/workflows/trigger-test-coverage-detector.yml
+++ b/.github/workflows/trigger-test-coverage-detector.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   actions: read
   contents: write
+  copilot-requests: write
   issues: write
   pull-requests: write
 

--- a/.github/workflows/trigger-text-auditor.yml
+++ b/.github/workflows/trigger-text-auditor.yml
@@ -7,11 +7,12 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
+  copilot-requests: write
   issues: write
   pull-requests: write
 
-  actions: read
 jobs:
   run:
     uses: ./.github/workflows/gh-aw-text-auditor.lock.yml

--- a/.github/workflows/trigger-update-pr-body.yml
+++ b/.github/workflows/trigger-update-pr-body.yml
@@ -6,7 +6,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: read
   pull-requests: write
 

--- a/.github/workflows/trigger-ux-design-patrol.yml
+++ b/.github/workflows/trigger-ux-design-patrol.yml
@@ -7,7 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ lint-workflows: setup-actionlint
 		\); \
 	) 2>/dev/null | while read -r file; do \
 		echo "Checking $$file..."; \
-		$$ACTIONLINT "$$file" || exit 1; \
+		$$ACTIONLINT -ignore 'unknown permission scope "copilot-requests"' "$$file" || exit 1; \
 	done
 
 setup-action-validator:

--- a/gh-agent-workflows/agent-suggestions/example.yml
+++ b/gh-agent-workflows/agent-suggestions/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/autonomy-atomicity-analyzer/example.yml
+++ b/gh-agent-workflows/autonomy-atomicity-analyzer/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/branch-actions-detective/example.yml
+++ b/gh-agent-workflows/branch-actions-detective/example.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
 
 jobs:

--- a/gh-agent-workflows/breaking-change-detector/example.yml
+++ b/gh-agent-workflows/breaking-change-detector/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/bug-hunter/example.yml
+++ b/gh-agent-workflows/bug-hunter/example.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/code-complexity-detector/example.yml
+++ b/gh-agent-workflows/code-complexity-detector/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/code-duplication-detector/example.yml
+++ b/gh-agent-workflows/code-duplication-detector/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/dependency-review/example.yml
+++ b/gh-agent-workflows/dependency-review/example.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: write
 

--- a/gh-agent-workflows/docs-patrol/example.yml
+++ b/gh-agent-workflows/docs-patrol/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/duplicate-issue-detector/example.yml
+++ b/gh-agent-workflows/duplicate-issue-detector/example.yml
@@ -4,8 +4,9 @@ on:
     types: [opened]
 
 permissions:
+  actions: read
   contents: read
-  discussions: write
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/estc-actions-resource-not-accessible-detector/example.yml
+++ b/gh-agent-workflows/estc-actions-resource-not-accessible-detector/example.yml
@@ -11,8 +11,10 @@ on:
 
 permissions:
   actions: read
-  issues: write
   contents: read
+  copilot-requests: write
+  issues: write
+  pull-requests: read
 
 jobs:
   run:

--- a/gh-agent-workflows/estc-docs-patrol-external/example.yml
+++ b/gh-agent-workflows/estc-docs-patrol-external/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/estc-docs-pr-review/example.yml
+++ b/gh-agent-workflows/estc-docs-pr-review/example.yml
@@ -4,11 +4,12 @@ on:
     types: [created]
 
 permissions:
+  actions: read
+  checks: read
   contents: read
+  copilot-requests: write
   issues: read
   pull-requests: write
-  checks: read
-  actions: read
 
 jobs:
   run:

--- a/gh-agent-workflows/estc-newbie-contributor-patrol-external/example.yml
+++ b/gh-agent-workflows/estc-newbie-contributor-patrol-external/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/estc-pr-buildkite-detective/example.yml
+++ b/gh-agent-workflows/estc-pr-buildkite-detective/example.yml
@@ -7,8 +7,8 @@ on:
 permissions:
   actions: read
   contents: read
-  discussions: write
-  issues: write
+  copilot-requests: write
+  issues: read
   pull-requests: write  # required by gh-aw compiler for add-comment (github/gh-aw#16673)
 
 jobs:

--- a/gh-agent-workflows/flaky-test-investigator/example.yml
+++ b/gh-agent-workflows/flaky-test-investigator/example.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/framework-best-practices/example.yml
+++ b/gh-agent-workflows/framework-best-practices/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/information-architecture/example.yml
+++ b/gh-agent-workflows/information-architecture/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/internal-downstream-health/example.yml
+++ b/gh-agent-workflows/internal-downstream-health/example.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/internal-gemini-cli-web-search/example.yml
+++ b/gh-agent-workflows/internal-gemini-cli-web-search/example.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/internal-gemini-cli/example.yml
+++ b/gh-agent-workflows/internal-gemini-cli/example.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/issue-fixer/example.yml
+++ b/gh-agent-workflows/issue-fixer/example.yml
@@ -5,7 +5,8 @@ on:
 
 permissions:
   actions: read
-  contents: read
+  contents: write
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/issue-triage/example.yml
+++ b/gh-agent-workflows/issue-triage/example.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/mention-in-issue-no-sandbox/example.yml
+++ b/gh-agent-workflows/mention-in-issue-no-sandbox/example.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   actions: read
   contents: write
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/mention-in-issue/example.yml
+++ b/gh-agent-workflows/mention-in-issue/example.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   actions: read
   contents: write
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/mention-in-pr-no-sandbox/example.yml
+++ b/gh-agent-workflows/mention-in-pr-no-sandbox/example.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: read
   contents: write
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/mention-in-pr/example.yml
+++ b/gh-agent-workflows/mention-in-pr/example.yml
@@ -8,8 +8,8 @@ on:
 permissions:
   actions: read
   contents: write
-  discussions: write
-  issues: write
+  copilot-requests: write
+  issues: read
   pull-requests: write
 
 jobs:

--- a/gh-agent-workflows/newbie-contributor-patrol/example.yml
+++ b/gh-agent-workflows/newbie-contributor-patrol/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/performance-profiler/example.yml
+++ b/gh-agent-workflows/performance-profiler/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/plan/example.yml
+++ b/gh-agent-workflows/plan/example.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   discussions: write
   issues: write
   pull-requests: write

--- a/gh-agent-workflows/pr-actions-detective/example.yml
+++ b/gh-agent-workflows/pr-actions-detective/example.yml
@@ -7,8 +7,9 @@ on:
 permissions:
   actions: read
   contents: read
-  issues: write
-  pull-requests: read
+  copilot-requests: write
+  issues: read
+  pull-requests: write
 
 jobs:
   run:

--- a/gh-agent-workflows/pr-actions-fixer/example.yml
+++ b/gh-agent-workflows/pr-actions-fixer/example.yml
@@ -10,7 +10,8 @@ on:
 permissions:
   actions: read
   contents: write
-  issues: write
+  copilot-requests: write
+  issues: read
   pull-requests: write
 
 jobs:

--- a/gh-agent-workflows/pr-labeler/example.yml
+++ b/gh-agent-workflows/pr-labeler/example.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: write
 

--- a/gh-agent-workflows/pr-review-addresser/example.yml
+++ b/gh-agent-workflows/pr-review-addresser/example.yml
@@ -6,9 +6,9 @@ on:
 permissions:
   actions: read
   contents: write
-  issues: write
+  copilot-requests: write
+  issues: read
   pull-requests: write
-
 concurrency:
   group: pr-review-addresser-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/gh-agent-workflows/pr-review/example.yml
+++ b/gh-agent-workflows/pr-review/example.yml
@@ -6,7 +6,8 @@ on:
 permissions:
   actions: read
   contents: read
-  issues: write  # needed for no-op run tracking issue
+  copilot-requests: write
+  issues: read  # needed for no-op run tracking issue
   pull-requests: write
 
 jobs:

--- a/gh-agent-workflows/product-manager-impersonator/example.yml
+++ b/gh-agent-workflows/product-manager-impersonator/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/project-summary/example.yml
+++ b/gh-agent-workflows/project-summary/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/refactor-opportunist/example.yml
+++ b/gh-agent-workflows/refactor-opportunist/example.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/release-update/example.yml
+++ b/gh-agent-workflows/release-update/example.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: read
   contents: write
+  copilot-requests: write
   issues: write
   pull-requests: write
 

--- a/gh-agent-workflows/scheduled-audit/example.yml
+++ b/gh-agent-workflows/scheduled-audit/example.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/scheduled-fix/example.yml
+++ b/gh-agent-workflows/scheduled-fix/example.yml
@@ -6,8 +6,9 @@ on:
 
 permissions:
   actions: read
-  contents: read
-  issues: read
+  contents: write
+  copilot-requests: write
+  issues: write
   pull-requests: write
 
 jobs:

--- a/gh-agent-workflows/small-problem-fixer/example.yml
+++ b/gh-agent-workflows/small-problem-fixer/example.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: read
   contents: write
+  copilot-requests: write
   issues: write
   pull-requests: write
 

--- a/gh-agent-workflows/stale-issues-investigator/example.yml
+++ b/gh-agent-workflows/stale-issues-investigator/example.yml
@@ -5,9 +5,11 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:

--- a/gh-agent-workflows/stale-issues-remediator/example.yml
+++ b/gh-agent-workflows/stale-issues-remediator/example.yml
@@ -5,8 +5,11 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
+  pull-requests: write
 
 jobs:
   run:

--- a/gh-agent-workflows/test-coverage-detector/example.yml
+++ b/gh-agent-workflows/test-coverage-detector/example.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/text-auditor/example.yml
+++ b/gh-agent-workflows/text-auditor/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 

--- a/gh-agent-workflows/update-pr-body/example.yml
+++ b/gh-agent-workflows/update-pr-body/example.yml
@@ -4,7 +4,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: read
   pull-requests: write
 

--- a/gh-agent-workflows/ux-design-patrol/example.yml
+++ b/gh-agent-workflows/ux-design-patrol/example.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: read
 


### PR DESCRIPTION
## Summary
- Align all trigger workflow and `gh-agent-workflows/*/example.yml` permissions with the minimum union required by their GH-AW `.lock.yml` callee jobs.
- Add missing `copilot-requests: write` so nested `agent` and `detection` jobs can run when triggers call reusable lock workflows.
- Tighten or raise other scopes only where lock files require it (e.g. `pull-requests: write` on detective workflows).

## Test plan
- [x] Compared trigger permissions against lock-file job permission unions for all 36 local trigger workflows
- [x] Regenerated dogfood triggers via `./scripts/dogfood.sh`
- [x] Manually fixed `trigger-prompt-audit.yml` and `trigger-pr-conflict-addresser.yml`

## Risks / Known Gaps
- Repos must have the `copilot-requests` feature enabled for agent workflows to run after this change.

Fixes: https://github.com/elastic/ai-github-actions/actions/runs/27674230156

Related issue: https://github.com/elastic/observability-robots/issues/4634
