### PR TITLE
fix mention in pr

### DIFF
--- a/.github/workflows/trigger-mention-in-pr.yml
+++ b/.github/workflows/trigger-mention-in-pr.yml
@@ -11,7 +11,8 @@ permissions:
   actions: read
   contents: write
   copilot-requests: write
-  issues: read
+  discussions: write
+  issues: write
   pull-requests: write
 
 jobs:

--- a/gh-agent-workflows/mention-in-pr/example.yml
+++ b/gh-agent-workflows/mention-in-pr/example.yml
@@ -9,7 +9,8 @@ permissions:
   actions: read
   contents: write
   copilot-requests: write
-  issues: read
+  discussions: write
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary

Fixes

```
fix Invalid workflow file: .github/workflows/trigger-mention-in-pr.yml#L18
The workflow is not valid. .github/workflows/trigger-mention-in-pr.yml (Line: 18, Col: 3): Error calling workflow 'elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@038d4f7b0986ad158aa9efe8f28a41df4e71b48f'. The nested job 'activation' is requesting 'discussions: write, issues: write', but is only allowed 'discussions: none, issues: read'.
```
## Validation

<!-- List the commands run to verify the changes -->

```bash
make compile          # sync triggers + compile to lock files
make lint             # run all linters
```

## Pre-Completion Checklist

- [ ] Re-read the issue or request and confirmed this PR directly addresses it
- [ ] Reviewed all changed files for correctness
- [ ] Ran `make compile` and `make lint` with no errors
- [ ] Verified no unrelated files were modified
