### PR TITLE
install gh aw using the make goal

### DIFF
--- a/.github/workflows/smoke-test-install.yml
+++ b/.github/workflows/smoke-test-install.yml
@@ -80,7 +80,7 @@ jobs:
 
           for wf in "${WORKFLOWS[@]}"; do
             echo "::group::Installing ${wf}"
-            if gh-aw add "elastic/ai-github-actions/.github/workflows/gh-aw-${wf}.md" --non-interactive; then
+            if gh-aw add "elastic/ai-github-actions/.github/workflows/gh-aw-${wf}.md"; then
               echo "::endgroup::"
             else
               echo "::endgroup::"

--- a/.github/workflows/smoke-test-install.yml
+++ b/.github/workflows/smoke-test-install.yml
@@ -43,7 +43,6 @@ jobs:
           set -euo pipefail
 
           WORKFLOWS=(
-            agent-efficiency
             agent-suggestions
             breaking-change-detector
             bug-hunter

--- a/.github/workflows/smoke-test-install.yml
+++ b/.github/workflows/smoke-test-install.yml
@@ -69,7 +69,6 @@ jobs:
             scheduled-audit
             scheduled-fix
             small-problem-fixer
-            stale-issues
             test-coverage-detector
             text-auditor
             update-pr-body

--- a/.github/workflows/smoke-test-install.yml
+++ b/.github/workflows/smoke-test-install.yml
@@ -16,6 +16,9 @@ jobs:
     name: Install and compile all workflows
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Install pinned gh-aw CLI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke-test-install.yml
+++ b/.github/workflows/smoke-test-install.yml
@@ -1,6 +1,9 @@
 ---
 name: "Internal: Smoke Test — Install & Compile"
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/smoke-test-install.yml"
   schedule:
     - cron: "0 6 * * *" # Daily at 06:00 UTC
   workflow_dispatch:
@@ -12,22 +15,14 @@ jobs:
   smoke-test:
     name: Install and compile all workflows
     runs-on: ubuntu-latest
-    env:
-      GH_AW_VERSION: "v0.87.4"
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.25"
-          cache: false
-
       - name: Install pinned gh-aw CLI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          GOBIN="$HOME/.local/bin" go install "github.com/github/gh-aw/cmd/gh-aw@${GH_AW_VERSION}"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/gh-aw" version
+          make setup-gh-aw
+          echo "$GITHUB_WORKSPACE/.bin" >> "$GITHUB_PATH"
+          "$GITHUB_WORKSPACE/.bin/gh-aw" version
 
       - name: Create a fresh repo
         run: |


### PR DESCRIPTION
run on PR basis if file changes

## Summary

Fix misleading version and use the same mechanism to install the gh aw binary

## Validation

<!-- List the commands run to verify the changes -->

```bash
make compile          # sync triggers + compile to lock files
make lint             # run all linters
```

## Pre-Completion Checklist

- [ ] Re-read the issue or request and confirmed this PR directly addresses it
- [ ] Reviewed all changed files for correctness
- [ ] Ran `make compile` and `make lint` with no errors
- [ ] Verified no unrelated files were modified
