### PR TITLE
fix(gh-aw): widen create-pr harness retries for Copilot 502s

### DIFF
--- a/.github/workflows/gh-aw-create-pr-from-issue.lock.yml
+++ b/.github/workflows/gh-aw-create-pr-from-issue.lock.yml
@@ -1882,7 +1882,7 @@ jobs:
           GH_AW_DAILY_AI_CREDITS_THRESHOLD: ${{ needs.activation.outputs.daily_ai_credits_threshold }}
           GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"${{ inputs.messages-footer || format('---\\n[What is this?](https://ela.st/github-ai-tools) | [From workflow: {0}]({{run_url}})\\n\\nGive us feedback! React with 🚀 if perfect, 👍 if helpful, 👎 if not.', github.workflow) }}\",\"activationComments\":\"false\"}"
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: ${{ inputs.report-failure-as-issue && 'true' || 'false' }}
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "90"
@@ -1904,7 +1904,7 @@ jobs:
           GH_AW_WORKFLOW_NAME: "Create PR From Issue"
           GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/gh-aw-create-pr-from-issue.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_AW_REPORT_FAILED_JOBS: "true"
+          GH_AW_REPORT_FAILED_JOBS: ${{ inputs.report-failure-as-issue && 'true' || 'false' }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/gh-aw-create-pr-from-issue.lock.yml
+++ b/.github/workflows/gh-aw-create-pr-from-issue.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"439f0864957de8144de00c543c74b73f4729956cee9eef5df2d946dd0e113249","body_hash":"476f72547afd3b4a16067b501e96564ccd28bc405a71699c4f33cf1ae2412434","compiler_version":"v0.87.10","agent_id":"copilot","agent_model":"${{ inputs.model }}","engine_versions":{"copilot":"1.0.80"}}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"720f70b8a9372365e34bf0532034de971581345cf2a89bad735328dc934fa41a","body_hash":"476f72547afd3b4a16067b501e96564ccd28bc405a71699c4f33cf1ae2412434","compiler_version":"v0.87.10","agent_id":"copilot","agent_model":"${{ inputs.model }}","engine_versions":{"copilot":"1.0.80"}}
 # gh-aw-manifest: {"version":1,"secrets":["EXTRA_COMMIT_GITHUB_TOKEN","GH_AW_DEFAULT_OTLP_HEADERS","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/cache/save","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/checkout","sha":"3d3c42e5aac5ba805825da76410c181273ba90b1","version":"v7.0.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-go","sha":"b7ad1dad31e06c5925ef5d2fc7ad053ef454303e","version":"v7.0.0"},{"repo":"actions/setup-node","sha":"249970729cb0ef3589644e2896645e5dc5ba9c38","version":"v6"},{"repo":"actions/setup-python","sha":"5fda3b95a4ea91299a34e894583c3862153e4b97","version":"v7.0.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86","version":"v5"},{"repo":"github/gh-aw-actions/setup-cli","sha":"bc8c008a419c5b7a29df6f5641edd35fd1c6ea85","version":"v0.87.10"},{"repo":"github/gh-aw/actions/setup","sha":"ff62cdbec36230acbae869ddb28806e8eca01ea1","version":"v0.87.10"},{"repo":"ruby/setup-ruby","sha":"95ef2b042f9d7a56d8268cba8559e2842e2ad01b","version":"v1.321.0 (source v1)"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.28.10","digest":"sha256:c01e6d16d11ea4f2a46cc023a9f402224a3b3861b026818eec0dc586d7e6918e","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.28.10@sha256:c01e6d16d11ea4f2a46cc023a9f402224a3b3861b026818eec0dc586d7e6918e"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.28.10","digest":"sha256:c3a18aebb8251339117ea998296315de17bada366f8d03919b3348ea71112e64","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.28.10@sha256:c3a18aebb8251339117ea998296315de17bada366f8d03919b3348ea71112e64"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.28.10","digest":"sha256:c06076f7aca95df713e0748c44d80c0a3c2538fad67bfdd04296d45158e083e6","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.28.10@sha256:c06076f7aca95df713e0748c44d80c0a3c2538fad67bfdd04296d45158e083e6"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.4.14","digest":"sha256:b2f0c2b2f17b5fbe809e5bb99dc185b6ddd70df25295dc63a6d526350334eff5","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.4.14@sha256:b2f0c2b2f17b5fbe809e5bb99dc185b6ddd70df25295dc63a6d526350334eff5"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:bac2192f6374d6262116399b34fc5e143d576f82719e90a18261cae7480f4d4e","pinned_image":"ghcr.io/github/gh-aw-node@sha256:bac2192f6374d6262116399b34fc5e143d576f82719e90a18261cae7480f4d4e"},{"image":"ghcr.io/github/github-mcp-server:v1.11.0","digest":"sha256:fbec75de11c255213fa08d80fb166abe73d851fff631c51c0079872967720699","pinned_image":"ghcr.io/github/github-mcp-server:v1.11.0@sha256:fbec75de11c255213fa08d80fb166abe73d851fff631c51c0079872967720699"},{"image":"mcr.microsoft.com/playwright/mcp","digest":"sha256:18c0a9c934004fe9580cc79f1e8e6e6cde7c667348b215335e8a23fd3e509804","pinned_image":"mcr.microsoft.com/playwright/mcp@sha256:18c0a9c934004fe9580cc79f1e8e6e6cde7c667348b215335e8a23fd3e509804"}],"mcp_servers":[{"name":"github","tools":["actions_get","actions_list","get_commit","get_file_contents","get_job_logs","get_latest_release","get_pull_request","get_pull_request_comments","get_pull_request_diff","get_pull_request_files","get_pull_request_review_comments","get_pull_request_reviews","get_pull_request_status","get_release_by_tag","get_tag","issue_read","list_branches","list_commits","list_issue_types","list_issues","list_pull_requests","list_releases","list_starred_repositories","list_tags","pull_request_read","search_code","search_issues","search_pull_requests","search_repositories"]},{"name":"mcpscripts","tools":["ready-to-make-pr"]},{"name":"playwright","tools":["browser_click","browser_close","browser_console_messages","browser_drag","browser_evaluate","browser_file_upload","browser_fill_form","browser_handle_dialog","browser_hover","browser_install","browser_navigate","browser_navigate_back","browser_network_requests","browser_press_key","browser_resize","browser_select_option","browser_snapshot","browser_tabs","browser_take_screenshot","browser_type","browser_wait_for"]},{"name":"public-code-search","tools":["search_code"]},{"name":"safeoutputs","tools":["add_comment","create_pull_request","missing_data","missing_tool","noop"]}]}
 # This file was automatically generated by gh-aw (v0.87.10). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
@@ -481,7 +481,7 @@ jobs:
       pull-requests: read
     concurrency:
       group: "gh-aw-copilot-${{ github.workflow }}-create-pr-from-issue-${{ inputs.target-issue-number }}"
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -1332,7 +1332,7 @@ jobs:
         # --allow-tool shell
         # --allow-tool web_fetch
         # --allow-tool write
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           set -o pipefail
           printf '%s' "$(date +%s%3N)" > /tmp/gh-aw/agent_cli_start_ms.txt
@@ -1390,6 +1390,10 @@ jobs:
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
           COPILOT_MODEL: ${{ inputs.model }}
+          GH_AW_HARNESS_BACKOFF_MULTIPLIER: 2
+          GH_AW_HARNESS_INITIAL_DELAY_MS: 30000
+          GH_AW_HARNESS_MAX_DELAY_MS: 180000
+          GH_AW_HARNESS_MAX_RETRIES: 6
           GH_AW_INPUT_DRAFT_PRS: ${{ inputs.draft-prs }}
           GH_AW_INPUT_TARGET_ISSUE_NUMBER: ${{ inputs.target-issue-number }}
           GH_AW_LLM_PROVIDER: github
@@ -1399,7 +1403,7 @@ jobs:
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_TIMEOUT_MINUTES: 60
+          GH_AW_TIMEOUT_MINUTES: 90
           GH_AW_VERSION: v0.87.10
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_AW: true
@@ -1423,7 +1427,7 @@ jobs:
         continue-on-error: true
         env:
           GH_AW_AGENTIC_EXECUTION_OUTCOME: ${{ steps.agentic_execution.outcome }}
-          GH_AW_ENGINE_STEP_TIMEOUT_MINUTES: 60
+          GH_AW_ENGINE_STEP_TIMEOUT_MINUTES: 90
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -1878,10 +1882,10 @@ jobs:
           GH_AW_DAILY_AI_CREDITS_THRESHOLD: ${{ needs.activation.outputs.daily_ai_credits_threshold }}
           GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"${{ inputs.messages-footer || format('---\\n[What is this?](https://ela.st/github-ai-tools) | [From workflow: {0}]({{run_url}})\\n\\nGive us feedback! React with 🚀 if perfect, 👍 if helpful, 👎 if not.', github.workflow) }}\",\"activationComments\":\"false\"}"
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: ${{ inputs.report-failure-as-issue && 'true' || 'false' }}
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
-          GH_AW_TIMEOUT_MINUTES: "60"
+          GH_AW_TIMEOUT_MINUTES: "90"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1900,7 +1904,7 @@ jobs:
           GH_AW_WORKFLOW_NAME: "Create PR From Issue"
           GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/gh-aw-create-pr-from-issue.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_AW_REPORT_FAILED_JOBS: ${{ inputs.report-failure-as-issue && 'true' || 'false' }}
+          GH_AW_REPORT_FAILED_JOBS: "true"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -2048,7 +2052,10 @@ jobs:
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
           COPILOT_MODEL: ${{ inputs.model }}
-          GH_AW_HARNESS_MAX_RETRIES: 0
+          GH_AW_HARNESS_BACKOFF_MULTIPLIER: 2
+          GH_AW_HARNESS_INITIAL_DELAY_MS: 30000
+          GH_AW_HARNESS_MAX_DELAY_MS: 180000
+          GH_AW_HARNESS_MAX_RETRIES: 6
           GH_AW_LLM_PROVIDER: github
           GH_AW_MAX_AI_CREDITS: ${{ vars.GH_AW_DEFAULT_DETECTION_MAX_AI_CREDITS || '400' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}

--- a/.github/workflows/gh-aw-create-pr-from-issue.md
+++ b/.github/workflows/gh-aw-create-pr-from-issue.md
@@ -19,6 +19,16 @@ engine:
   model: ${{ inputs.model }}
   concurrency:
     group: "gh-aw-copilot-${{ github.workflow }}-create-pr-from-issue-${{ inputs.target-issue-number }}"
+  # Wider than defaults so short Copilot CAPI 502 / proxy outages can clear
+  # without abandoning the PR stage after an audit issue was already filed.
+  # Note: with compiler v0.87.10 this also applies to threat-detection (nested
+  # threat-detection.engine.harness is not supported yet). Detection only runs
+  # after the agent produces output and is continue-on-error.
+  harness:
+    max-retries: 6
+    initial-delay-ms: 30000
+    backoff-multiplier: 2
+    max-delay-ms: 180000
 on:
   stale-check: false
   workflow_call:
@@ -89,7 +99,7 @@ safe-outputs:
     issues: true
     discussions: false
     target: "${{ inputs.target-issue-number }}"
-timeout-minutes: 60
+timeout-minutes: 90
 steps:
   - name: Repo-specific setup
     if: ${{ inputs.setup-commands != '' }}


### PR DESCRIPTION
## Summary

- Widen Copilot harness retries/backoff on `gh-aw-create-pr-from-issue` so short `CAPIError: 502 "Proxy error"` outages are less likely to abandon the PR stage after an audit issue was filed
- Set workflow `timeout-minutes` to `90` (from `60`) in the source workflow and recompiled lock
- Document that, on compiler `v0.87.10`, these harness settings also apply to the nested threat-detection pass in this workflow

## Merge order

**Merge this PR first**, before the companion `oblt-aw` change. Consumers call this lock at `@main`.

Companion: autodoc `notify-fix-failure` in `elastic/oblt-aw` (opened as a follow-up PR from the same tracking issue).

## Test plan

- [ ] Confirm compiled lock sets `GH_AW_HARNESS_MAX_RETRIES: 6`, `INITIAL_DELAY_MS: 30000`, `MAX_DELAY_MS: 180000`
- [ ] Confirm `timeout-minutes: 90` on agent jobs
- [ ] CI / compile checks pass

Related issue: https://github.com/elastic/observability-robots/issues/5049

---
The body of this PR [is automatically managed](https://ela.st/github-ai-tools) by the [Trigger Update PR Body workflow](https://github.com/elastic/ai-github-actions/actions/runs/33650894369).

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 33650894369, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions/actions/runs/33650894369 -->